### PR TITLE
feat: port OWPML header.xml parser (closes #2)

### DIFF
--- a/crates/hwp-dvc-core/src/document/header/mod.rs
+++ b/crates/hwp-dvc-core/src/document/header/mod.rs
@@ -1,0 +1,69 @@
+//! OWPML `Contents/header.xml` parser: shape tables.
+//!
+//! This module parses the six ID-indexed tables that every Phase 2
+//! validator needs: character shapes, paragraph shapes, border fills,
+//! styles, bullets, and numberings. Together with the font-face list
+//! they are the bedrock of validation because the section XML only
+//! carries *references* — integer IDs — into them.
+//!
+//! See `references/dvc/Source/RCharShape.{h,cpp}`,
+//! `RParaShape.{h,cpp}`, `RTable.{h,cpp}` (border-fills portion),
+//! `RBullets.{h,cpp}`, and `ROutlineShape.{h,cpp}` for the canonical
+//! C++ shape.
+//!
+//! # Entry point
+//!
+//! [`super::HwpxArchive::read_header`] is the one function callers are
+//! expected to use. It locates `Contents/header.xml` inside the
+//! archive and returns a populated [`HeaderTables`].
+
+pub mod parser;
+pub mod types;
+
+use std::collections::HashMap;
+
+pub use types::{
+    Border, BorderFill, Bullet, CharShape, FontFace, FontLang, HAlign, HeadingType, LangTuple,
+    LineBreakWord, LineSpacing, LineSpacingType, LineType, Margin, Numbering, ParaHead, ParaShape,
+    Style, VAlign,
+};
+
+/// The parsed header-side shape tables for an HWPX document.
+///
+/// All maps are keyed by the OWPML-assigned `id` attribute, which is
+/// the same integer a section XML paragraph uses to reference the
+/// shape. IDs are `u32` because the reference models them as `UINT`.
+///
+/// `font_faces` stays a `Vec` (not a map) because the key space is the
+/// language enum, not an integer id, and there are only seven entries.
+#[derive(Debug, Default, Clone)]
+pub struct HeaderTables {
+    pub char_shapes: HashMap<u32, CharShape>,
+    pub para_shapes: HashMap<u32, ParaShape>,
+    pub border_fills: HashMap<u32, BorderFill>,
+    pub styles: HashMap<u32, Style>,
+    pub bullets: HashMap<u32, Bullet>,
+    pub numberings: HashMap<u32, Numbering>,
+    pub font_faces: Vec<FontFace>,
+}
+
+impl HeaderTables {
+    /// Find the [`FontFace`] for a given language.
+    pub fn font_face(&self, lang: FontLang) -> Option<&FontFace> {
+        self.font_faces.iter().find(|f| f.lang == lang)
+    }
+
+    /// Resolve a `CharShape.font_ref[lang]` to a face name in one call.
+    pub fn font_name(&self, char_shape_id: u32, lang: FontLang) -> Option<&str> {
+        let cs = self.char_shapes.get(&char_shape_id)?;
+        cs.font_name(lang, &self.font_faces)
+    }
+
+    /// Find a [`Style`] by its `name` attribute (e.g. `"바탕글"`,
+    /// `"테스트스타일"`). Names are not unique in general, so returns
+    /// the first match. Prefer the id-keyed `styles.get` when you have
+    /// the id.
+    pub fn style_by_name(&self, name: &str) -> Option<&Style> {
+        self.styles.values().find(|s| s.name == name)
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/border_fills.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/border_fills.rs
@@ -1,0 +1,93 @@
+//! `<hh:borderFills>` — cell-border decorations keyed by `id`.
+
+use std::io::BufRead;
+
+use quick_xml::events::attributes::Attributes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::header::types::{Border, BorderFill, LineType};
+use crate::document::header::HeaderTables;
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{attr_bool, attr_string, attr_u32, local_name, parse_width_mm, skip};
+
+pub(super) fn parse<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"borderFill" => {
+                let mut bf = BorderFill {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    three_d: attr_bool(e.attributes(), b"threeD")?,
+                    shadow: attr_bool(e.attributes(), b"shadow")?,
+                    center_line: attr_string(e.attributes(), b"centerLine")?,
+                    break_cell_separate_line: attr_bool(e.attributes(), b"breakCellSeparateLine")?,
+                    ..Default::default()
+                };
+                parse_border_fill_body(reader, &mut bf)?;
+                tables.border_fills.insert(bf.id, bf);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"borderFills" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <borderFills>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_border_fill_body<B: BufRead>(
+    reader: &mut Reader<B>,
+    bf: &mut BorderFill,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Empty(e) | Event::Start(e) => {
+                let name = local_name(e.name());
+                let is_start = matches!(ev, Event::Start(_));
+                match name {
+                    b"leftBorder" => bf.left = parse_border(e.attributes())?,
+                    b"rightBorder" => bf.right = parse_border(e.attributes())?,
+                    b"topBorder" => bf.top = parse_border(e.attributes())?,
+                    b"bottomBorder" => bf.bottom = parse_border(e.attributes())?,
+                    b"diagonal" => bf.diagonal = parse_border(e.attributes())?,
+                    b"fillBrush" => bf.has_fill_brush = true,
+                    _ => {}
+                }
+                if is_start {
+                    skip(reader, e)?;
+                }
+            }
+            Event::End(e) if local_name(e.name()) == b"borderFill" => return Ok(()),
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <borderFill>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_border(attrs: Attributes<'_>) -> DvcResult<Border> {
+    let type_str = attr_string(attrs.clone(), b"type")?;
+    let width_str = attr_string(attrs.clone(), b"width")?;
+    let color = attr_string(attrs, b"color")?;
+    Ok(Border {
+        line_type: LineType::parse(&type_str),
+        width_mm: parse_width_mm(&width_str),
+        color,
+    })
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/char_shapes.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/char_shapes.rs
@@ -1,0 +1,102 @@
+//! `<hh:charProperties>` — character-shape records keyed by `id`.
+
+use std::io::BufRead;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::header::types::CharShape;
+use crate::document::header::HeaderTables;
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{
+    attr_bool, attr_string, attr_u32, local_name, parse_lang_tuple_i32, parse_lang_tuple_u32, skip,
+};
+
+pub(super) fn parse<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"charPr" => {
+                let mut cs = CharShape {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    height: attr_u32(e.attributes(), b"height")?,
+                    text_color: attr_string(e.attributes(), b"textColor")?,
+                    shade_color: attr_string(e.attributes(), b"shadeColor")?,
+                    use_font_space: attr_bool(e.attributes(), b"useFontSpace")?,
+                    use_kerning: attr_bool(e.attributes(), b"useKerning")?,
+                    sym_mark: attr_string(e.attributes(), b"symMark")?,
+                    border_fill_id_ref: attr_u32(e.attributes(), b"borderFillIDRef")?,
+                    ..Default::default()
+                };
+                parse_char_pr_body(reader, &mut cs)?;
+                tables.char_shapes.insert(cs.id, cs);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"charProperties" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <charProperties>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_char_pr_body<B: BufRead>(reader: &mut Reader<B>, cs: &mut CharShape) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Empty(e) | Event::Start(e) => {
+                let name = local_name(e.name());
+                let is_start = matches!(ev, Event::Start(_));
+                match name {
+                    b"fontRef" => cs.font_ref = parse_lang_tuple_u32(e.attributes())?,
+                    b"ratio" => cs.ratio = parse_lang_tuple_u32(e.attributes())?,
+                    b"spacing" => cs.spacing = parse_lang_tuple_i32(e.attributes())?,
+                    b"relSz" => cs.rel_sz = parse_lang_tuple_u32(e.attributes())?,
+                    b"offset" => cs.offset = parse_lang_tuple_i32(e.attributes())?,
+                    b"bold" => cs.bold = true,
+                    b"italic" => cs.italic = true,
+                    b"underline" => {
+                        // Present iff underline is active (reference uses
+                        // existence as the boolean); type/shape/color are
+                        // ignored for the header-table surface.
+                        cs.underline = true;
+                    }
+                    b"strikeout" => {
+                        let shape = attr_string(e.attributes(), b"shape")?;
+                        cs.strikeout = shape != "NONE" && !shape.is_empty();
+                    }
+                    b"outline" => {
+                        let t = attr_string(e.attributes(), b"type")?;
+                        cs.outline = t != "NONE" && !t.is_empty();
+                    }
+                    b"emboss" => cs.emboss = true,
+                    b"engrave" => cs.engrave = true,
+                    b"shadow" => {
+                        let t = attr_string(e.attributes(), b"type")?;
+                        cs.shadow = t != "NONE" && !t.is_empty();
+                    }
+                    b"supscript" => cs.supscript = true,
+                    b"subscript" => cs.subscript = true,
+                    _ => {}
+                }
+                if is_start {
+                    skip(reader, e)?;
+                }
+            }
+            Event::End(e) if local_name(e.name()) == b"charPr" => return Ok(()),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <charPr>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/common.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/common.rs
@@ -1,0 +1,162 @@
+//! Shared helpers for the header-XML parser: element-name extraction,
+//! generic `Reader::skip`, attribute coercion (string/u32/i32/bool),
+//! per-language 7-slot tuple decoding, and OWPML-specific width
+//! parsing. Kept in one file because every per-element submodule uses
+//! at least half of these.
+
+use std::io::BufRead;
+
+use quick_xml::events::attributes::{AttrError, Attributes};
+use quick_xml::events::BytesStart;
+use quick_xml::name::QName;
+use quick_xml::Reader;
+
+use crate::document::header::types::{FontLang, LangTuple};
+use crate::error::{DvcError, DvcResult};
+
+/// Wrap a `quick_xml` attribute error into [`DvcError::Document`].
+pub(super) fn xml_err(e: AttrError) -> DvcError {
+    DvcError::Document(format!("bad attribute: {e}"))
+}
+
+/// Return the local part of an element name (after the colon).
+pub(super) fn local_name<'a>(n: QName<'a>) -> &'a [u8] {
+    n.local_name().into_inner()
+}
+
+/// Skip to the matching end of `start`, discarding all interior events.
+pub(super) fn skip<B: BufRead>(reader: &mut Reader<B>, start: &BytesStart<'_>) -> DvcResult<()> {
+    reader.read_to_end_into(start.name(), &mut Vec::new())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Attribute helpers
+// ---------------------------------------------------------------------------
+
+pub(super) fn attr_str(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<Option<String>> {
+    for a in attrs {
+        let a = a.map_err(xml_err)?;
+        if local_name(a.key) == key {
+            let v = a
+                .unescape_value()
+                .map_err(|e| DvcError::Document(format!("attr decode: {e}")))?;
+            return Ok(Some(v.into_owned()));
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn attr_u32(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<u32> {
+    match attr_str(attrs, key)? {
+        Some(s) => s.trim().parse::<u32>().map_err(|e| {
+            DvcError::Document(format!(
+                "expected u32 for attribute '{}', got '{}': {e}",
+                String::from_utf8_lossy(key),
+                s
+            ))
+        }),
+        None => Ok(0),
+    }
+}
+
+pub(super) fn attr_i32(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<i32> {
+    match attr_str(attrs, key)? {
+        Some(s) => s.trim().parse::<i32>().map_err(|e| {
+            DvcError::Document(format!(
+                "expected i32 for attribute '{}', got '{}': {e}",
+                String::from_utf8_lossy(key),
+                s
+            ))
+        }),
+        None => Ok(0),
+    }
+}
+
+pub(super) fn attr_bool(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<bool> {
+    match attr_str(attrs, key)? {
+        Some(s) => Ok(matches!(s.trim(), "1" | "true" | "TRUE" | "True")),
+        None => Ok(false),
+    }
+}
+
+pub(super) fn attr_string(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<String> {
+    Ok(attr_str(attrs, key)?.unwrap_or_default())
+}
+
+/// Parse a width attribute value like `"0.12 mm"` into `f32` millimeters.
+pub(super) fn parse_width_mm(s: &str) -> f32 {
+    let trimmed = s.trim();
+    // Drop any trailing unit suffix (letters/whitespace).
+    let numeric_end = trimmed
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .unwrap_or(trimmed.len());
+    trimmed[..numeric_end].parse::<f32>().unwrap_or(0.0)
+}
+
+/// Map each [`FontLang`] to its OWPML attribute name inside per-language
+/// tuple elements (`<hh:fontRef hangul="..">`, `<hh:ratio ..>`, …).
+fn lang_attr_key(lang: FontLang) -> &'static [u8] {
+    match lang {
+        FontLang::Hangul => b"hangul",
+        FontLang::Latin => b"latin",
+        FontLang::Hanja => b"hanja",
+        FontLang::Japanese => b"japanese",
+        FontLang::Other => b"other",
+        FontLang::Symbol => b"symbol",
+        FontLang::User => b"user",
+    }
+}
+
+pub(super) fn parse_lang_tuple_u32(attrs: Attributes<'_>) -> DvcResult<LangTuple<u32>> {
+    let mut out = LangTuple::<u32>::default();
+    for &lang in &FontLang::ALL {
+        out.set(lang, attr_u32(attrs.clone(), lang_attr_key(lang))?);
+    }
+    Ok(out)
+}
+
+pub(super) fn parse_lang_tuple_i32(attrs: Attributes<'_>) -> DvcResult<LangTuple<i32>> {
+    let mut out = LangTuple::<i32>::default();
+    for &lang in &FontLang::ALL {
+        out.set(lang, attr_i32(attrs.clone(), lang_attr_key(lang))?);
+    }
+    Ok(out)
+}
+
+/// Read character data up to the element end with the given local name.
+/// Used for `<hh:paraHead>` which carries its template as text content
+/// (e.g., `^1.`).
+pub(super) fn read_text_until_end<B: BufRead>(
+    reader: &mut Reader<B>,
+    end_local: &[u8],
+) -> DvcResult<String> {
+    use quick_xml::events::Event;
+    let mut buf = Vec::new();
+    let mut out = String::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Text(t) => {
+                let decoded = t.decode().map_err(|e| {
+                    DvcError::Document(format!(
+                        "text decode in <{}>: {e}",
+                        String::from_utf8_lossy(end_local)
+                    ))
+                })?;
+                out.push_str(&decoded);
+            }
+            Event::End(ref e) if local_name(e.name()) == end_local => return Ok(out),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Empty(_) => {}
+            Event::Eof => {
+                return Err(DvcError::Document(format!(
+                    "unexpected EOF inside <{}>",
+                    String::from_utf8_lossy(end_local)
+                )))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/fontfaces.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/fontfaces.rs
@@ -1,0 +1,67 @@
+//! `<hh:fontfaces>` — per-language font-id → face-name maps.
+
+use std::io::BufRead;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::header::types::{FontFace, FontLang};
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{attr_string, attr_u32, local_name, skip};
+
+pub(super) fn parse<B: BufRead>(
+    reader: &mut Reader<B>,
+    out: &mut Vec<FontFace>,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"fontface" => {
+                let lang = attr_string(e.attributes(), b"lang")?;
+                let mut face = FontFace {
+                    lang: FontLang::parse(&lang).unwrap_or(FontLang::Hangul),
+                    ..Default::default()
+                };
+                parse_fontface_body(reader, &mut face)?;
+                out.push(face);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"fontfaces" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <fontfaces>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_fontface_body<B: BufRead>(reader: &mut Reader<B>, face: &mut FontFace) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Empty(ref e) | Event::Start(ref e) if local_name(e.name()) == b"font" => {
+                let id = attr_u32(e.attributes(), b"id")?;
+                let name = attr_string(e.attributes(), b"face")?;
+                face.fonts.insert(id, name);
+                if matches!(ev, Event::Start(_)) {
+                    skip(reader, e)?;
+                }
+            }
+            Event::End(ref e) if local_name(e.name()) == b"fontface" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <fontface>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/misc.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/misc.rs
@@ -1,0 +1,174 @@
+//! Smaller header tables: `<hh:styles>`, `<hh:bullets>`, `<hh:numberings>`.
+//! Grouped together because each fits comfortably in under 80 lines.
+
+use std::io::BufRead;
+
+use quick_xml::events::attributes::Attributes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::header::types::{Bullet, Numbering, ParaHead, Style};
+use crate::document::header::HeaderTables;
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{
+    attr_bool, attr_string, attr_u32, local_name, read_text_until_end, skip,
+};
+
+// ---------------------------------------------------------------------------
+// <hh:styles>
+// ---------------------------------------------------------------------------
+
+pub(super) fn parse_styles<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Empty(e) | Event::Start(e) if local_name(e.name()) == b"style" => {
+                let style = Style {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    style_type: attr_string(e.attributes(), b"type")?,
+                    name: attr_string(e.attributes(), b"name")?,
+                    eng_name: attr_string(e.attributes(), b"engName")?,
+                    para_pr_id_ref: attr_u32(e.attributes(), b"paraPrIDRef")?,
+                    char_pr_id_ref: attr_u32(e.attributes(), b"charPrIDRef")?,
+                    next_style_id_ref: attr_u32(e.attributes(), b"nextStyleIDRef")?,
+                    lang_id: attr_u32(e.attributes(), b"langID")?,
+                    lock_form: attr_bool(e.attributes(), b"lockForm")?,
+                };
+                if matches!(ev, Event::Start(_)) {
+                    skip(reader, e)?;
+                }
+                tables.styles.insert(style.id, style);
+            }
+            Event::End(e) if local_name(e.name()) == b"styles" => return Ok(()),
+            Event::Start(e) => skip(reader, e)?,
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <styles>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// <hh:bullets>
+// ---------------------------------------------------------------------------
+
+pub(super) fn parse_bullets<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"bullet" => {
+                let bullet = Bullet {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    char: attr_string(e.attributes(), b"char")?,
+                    use_image: attr_bool(e.attributes(), b"useImage")?,
+                };
+                skip(reader, e)?;
+                tables.bullets.insert(bullet.id, bullet);
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"bullet" => {
+                let bullet = Bullet {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    char: attr_string(e.attributes(), b"char")?,
+                    use_image: attr_bool(e.attributes(), b"useImage")?,
+                };
+                tables.bullets.insert(bullet.id, bullet);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"bullets" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document("unexpected EOF inside <bullets>".into()))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// <hh:numberings>
+// ---------------------------------------------------------------------------
+
+pub(super) fn parse_numberings<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"numbering" => {
+                let mut n = Numbering {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    start: attr_u32(e.attributes(), b"start")?,
+                    para_heads: Vec::new(),
+                };
+                parse_numbering_body(reader, &mut n)?;
+                tables.numberings.insert(n.id, n);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"numberings" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <numberings>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_numbering_body<B: BufRead>(reader: &mut Reader<B>, n: &mut Numbering) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"paraHead" => {
+                let head = parse_para_head_attrs(e.attributes())?;
+                let text = read_text_until_end(reader, b"paraHead")?;
+                n.para_heads.push(ParaHead {
+                    num_format_text: text,
+                    ..head
+                });
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"paraHead" => {
+                n.para_heads.push(parse_para_head_attrs(e.attributes())?);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"numbering" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <numbering>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_para_head_attrs(attrs: Attributes<'_>) -> DvcResult<ParaHead> {
+    Ok(ParaHead {
+        start: attr_u32(attrs.clone(), b"start")?,
+        level: attr_u32(attrs.clone(), b"level")?,
+        align: attr_string(attrs.clone(), b"align")?,
+        use_inst_width: attr_bool(attrs.clone(), b"useInstWidth")?,
+        auto_indent: attr_bool(attrs.clone(), b"autoIndent")?,
+        width_adjust: attr_bool(attrs.clone(), b"widthAdjust")?,
+        text_offset_type: attr_string(attrs.clone(), b"textOffsetType")?,
+        text_offset: attr_u32(attrs.clone(), b"textOffset")?,
+        num_format: attr_string(attrs.clone(), b"numFormat")?,
+        char_pr_id_ref: attr_u32(attrs.clone(), b"charPrIDRef")?,
+        checkable: attr_bool(attrs, b"checkable")?,
+        num_format_text: String::new(),
+    })
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/mod.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/mod.rs
@@ -1,0 +1,212 @@
+//! Event-driven parser for `Contents/header.xml`.
+//!
+//! The parser is deliberately tolerant of the `xmlns`-prefixed names
+//! that HWPX writers emit (`hh:charPr`, `hh:paraPr`, `hh:style`, …).
+//! We match on the **local name** (the part after the colon) and
+//! ignore the namespace declaration attributes. Namespaces aren't
+//! structurally meaningful for HWPX's header because the full prefix
+//! set is declared once at `<hh:head>`.
+//!
+//! Every unrecognized element is skipped with
+//! [`Reader::read_to_end_into`]-equivalent skipping. This keeps the
+//! parser forward-compatible: Hancom has already shipped at least two
+//! minor revisions that added attributes to existing elements without
+//! bumping the declared `version`.
+//!
+//! The parser is split across one file per top-level element group
+//! so that no single file exceeds the project's 500-line soft cap.
+
+mod border_fills;
+mod char_shapes;
+mod common;
+mod fontfaces;
+mod misc;
+mod para_shapes;
+
+use std::io::BufRead;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::error::DvcResult;
+
+use super::HeaderTables;
+use common::local_name;
+
+/// Parse an HWPX `header.xml` byte slice into [`HeaderTables`].
+pub fn parse_header(bytes: &[u8]) -> DvcResult<HeaderTables> {
+    let mut reader = Reader::from_reader(bytes);
+    let config = reader.config_mut();
+    config.trim_text(true);
+    config.expand_empty_elements = false;
+
+    let mut tables = HeaderTables::default();
+
+    dispatch(&mut reader, &mut tables)?;
+
+    Ok(tables)
+}
+
+fn dispatch<B: BufRead>(reader: &mut Reader<B>, tables: &mut HeaderTables) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) => match local_name(e.name()) {
+                b"fontfaces" => fontfaces::parse(reader, &mut tables.font_faces)?,
+                b"borderFills" => border_fills::parse(reader, tables)?,
+                b"charProperties" => char_shapes::parse(reader, tables)?,
+                b"paraProperties" => para_shapes::parse(reader, tables)?,
+                b"styles" => misc::parse_styles(reader, tables)?,
+                b"bullets" => misc::parse_bullets(reader, tables)?,
+                b"numberings" => misc::parse_numberings(reader, tables)?,
+                _ => {}
+            },
+            Event::Empty(_) => {
+                // Element with no children at top level — ignore.
+            }
+            Event::Eof => return Ok(()),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::header::types::{
+        FontLang, HAlign, HeadingType, LineBreakWord, LineSpacingType, LineType, VAlign,
+    };
+
+    /// A minimal, synthetic `header.xml` covering the shape categories
+    /// our parser targets. This is unit-level coverage complementing
+    /// the fixture-based integration tests in
+    /// `tests/header_parsing.rs`.
+    const MINI_HEADER: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"
+         xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+         xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+<hh:refList>
+<hh:fontfaces itemCnt="1">
+<hh:fontface lang="HANGUL" fontCnt="1">
+<hh:font id="0" face="TestFont" type="TTF" isEmbedded="0"/>
+</hh:fontface>
+</hh:fontfaces>
+<hh:borderFills itemCnt="1">
+<hh:borderFill id="1" threeD="0" shadow="0" centerLine="NONE" breakCellSeparateLine="0">
+<hh:slash type="NONE" Crooked="0" isCounter="0"/>
+<hh:backSlash type="NONE" Crooked="0" isCounter="0"/>
+<hh:leftBorder type="SOLID" width="0.12 mm" color="#000000"/>
+<hh:rightBorder type="SOLID" width="0.12 mm" color="#000000"/>
+<hh:topBorder type="SOLID" width="0.12 mm" color="#000000"/>
+<hh:bottomBorder type="DASH" width="0.12 mm" color="#000000"/>
+<hh:diagonal type="SOLID" width="0.1 mm" color="#000000"/>
+</hh:borderFill>
+</hh:borderFills>
+<hh:charProperties itemCnt="1">
+<hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE" borderFillIDRef="1">
+<hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+<hh:ratio hangul="100" latin="100" hanja="100" japanese="100" other="100" symbol="100" user="100"/>
+<hh:spacing hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+<hh:relSz hangul="100" latin="100" hanja="100" japanese="100" other="100" symbol="100" user="100"/>
+<hh:offset hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+</hh:charPr>
+</hh:charProperties>
+<hh:paraProperties itemCnt="1">
+<hh:paraPr id="0" tabPrIDRef="0" condense="0" fontLineHeight="0" snapToGrid="1" suppressLineNumbers="0" checked="0">
+<hh:align horizontal="JUSTIFY" vertical="BASELINE"/>
+<hh:heading type="NONE" idRef="0" level="0"/>
+<hh:breakSetting breakLatinWord="KEEP_WORD" breakNonLatinWord="KEEP_WORD" widowOrphan="0" keepWithNext="0" keepLines="0" pageBreakBefore="0" lineWrap="BREAK"/>
+<hh:autoSpacing eAsianEng="0" eAsianNum="0"/>
+<hh:margin><hc:indent value="0" unit="HWPUNIT"/><hc:left value="0" unit="HWPUNIT"/><hc:right value="0" unit="HWPUNIT"/><hc:prev value="0" unit="HWPUNIT"/><hc:next value="0" unit="HWPUNIT"/></hh:margin>
+<hh:lineSpacing type="PERCENT" value="160" unit="HWPUNIT"/>
+<hh:border borderFillIDRef="1" offsetLeft="0" offsetRight="0" offsetTop="0" offsetBottom="0" connect="0" ignoreMargin="0"/>
+</hh:paraPr>
+</hh:paraProperties>
+<hh:styles itemCnt="1">
+<hh:style id="0" type="PARA" name="바탕글" engName="Normal" paraPrIDRef="0" charPrIDRef="0" nextStyleIDRef="0" langID="1042" lockForm="0"/>
+</hh:styles>
+<hh:bullets itemCnt="1">
+<hh:bullet id="1" char="&#x25A1;" useImage="0"/>
+</hh:bullets>
+<hh:numberings itemCnt="1">
+<hh:numbering id="1" start="0">
+<hh:paraHead start="1" level="1" align="LEFT" useInstWidth="1" autoIndent="1" widthAdjust="0" textOffsetType="PERCENT" textOffset="50" numFormat="DIGIT" charPrIDRef="4294967295" checkable="0">^1.</hh:paraHead>
+</hh:numbering>
+</hh:numberings>
+</hh:refList>
+</hh:head>"##;
+
+    #[test]
+    fn parses_minimal_synthetic_header() {
+        let t = parse_header(MINI_HEADER.as_bytes()).expect("parse ok");
+
+        assert_eq!(t.font_faces.len(), 1);
+        assert_eq!(t.font_faces[0].lang, FontLang::Hangul);
+        assert_eq!(
+            t.font_faces[0].fonts.get(&0).map(String::as_str),
+            Some("TestFont")
+        );
+
+        let bf = t.border_fills.get(&1).expect("border_fill id=1");
+        assert_eq!(bf.left.line_type, LineType::Solid);
+        assert!((bf.left.width_mm - 0.12).abs() < 1e-6);
+        assert_eq!(bf.bottom.line_type, LineType::Dash);
+        assert!(
+            !bf.four_sides_solid(),
+            "bottom is DASH, so not all four sides solid"
+        );
+
+        let cs = t.char_shapes.get(&0).expect("charPr id=0");
+        assert_eq!(cs.height, 1000);
+        assert_eq!(cs.text_color, "#000000");
+        assert_eq!(cs.border_fill_id_ref, 1);
+        assert_eq!(cs.ratio.get(FontLang::Hangul), 100);
+        assert_eq!(
+            cs.font_name(FontLang::Hangul, &t.font_faces),
+            Some("TestFont")
+        );
+
+        let ps = t.para_shapes.get(&0).expect("paraPr id=0");
+        assert_eq!(ps.h_align, HAlign::Justify);
+        assert_eq!(ps.v_align, VAlign::Baseline);
+        assert_eq!(ps.heading_type, HeadingType::None);
+        assert_eq!(ps.break_latin_word, LineBreakWord::KeepWord);
+        assert_eq!(ps.line_spacing.type_, LineSpacingType::Percent);
+        assert_eq!(ps.line_spacing.value, 160);
+        assert_eq!(ps.border_fill_id_ref, 1);
+
+        let st = t.styles.get(&0).expect("style id=0");
+        assert_eq!(st.name, "바탕글");
+        assert_eq!(st.style_type, "PARA");
+
+        let b = t.bullets.get(&1).expect("bullet id=1");
+        assert_eq!(b.char, "\u{25A1}");
+        assert!(!b.use_image);
+
+        let n = t.numberings.get(&1).expect("numbering id=1");
+        assert_eq!(n.para_heads.len(), 1);
+        assert_eq!(n.para_heads[0].level, 1);
+        assert_eq!(n.para_heads[0].num_format, "DIGIT");
+        assert_eq!(n.para_heads[0].num_format_text, "^1.");
+    }
+
+    #[test]
+    fn missing_header_elements_produce_defaults() {
+        // A head with no refList at all should still parse.
+        let xml = r#"<?xml version="1.0"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"></hh:head>"#;
+        let t = parse_header(xml.as_bytes()).expect("parse empty head");
+        assert!(t.char_shapes.is_empty());
+        assert!(t.font_faces.is_empty());
+    }
+
+    #[test]
+    fn parse_width_mm_strips_unit() {
+        use super::common::parse_width_mm;
+        assert!((parse_width_mm("0.12 mm") - 0.12).abs() < 1e-6);
+        assert!((parse_width_mm("1.5mm") - 1.5).abs() < 1e-6);
+        assert!((parse_width_mm("3") - 3.0).abs() < 1e-6);
+        assert_eq!(parse_width_mm(""), 0.0);
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/parser/para_shapes.rs
+++ b/crates/hwp-dvc-core/src/document/header/parser/para_shapes.rs
@@ -1,0 +1,212 @@
+//! `<hh:paraProperties>` — paragraph-shape records keyed by `id`.
+//!
+//! The biggest single record in the header. The `<hp:switch>` wrapper
+//! around margin + lineSpacing is special-cased because HWPX emits
+//! both an `HwpUnitChar`-required case and a default-namespace
+//! fallback; the reference C++ always consumes the first branch.
+
+use std::io::BufRead;
+
+use quick_xml::events::attributes::Attributes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::header::types::{
+    HAlign, HeadingType, LineBreakWord, LineSpacing, LineSpacingType, Margin, ParaShape, VAlign,
+};
+use crate::document::header::HeaderTables;
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{attr_bool, attr_i32, attr_string, attr_u32, local_name, skip};
+
+pub(super) fn parse<B: BufRead>(
+    reader: &mut Reader<B>,
+    tables: &mut HeaderTables,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"paraPr" => {
+                let mut ps = ParaShape {
+                    id: attr_u32(e.attributes(), b"id")?,
+                    tab_pr_id_ref: attr_u32(e.attributes(), b"tabPrIDRef")?,
+                    condense: attr_u32(e.attributes(), b"condense")?,
+                    font_line_height: attr_bool(e.attributes(), b"fontLineHeight")?,
+                    snap_to_grid: attr_bool(e.attributes(), b"snapToGrid")?,
+                    suppress_line_numbers: attr_bool(e.attributes(), b"suppressLineNumbers")?,
+                    checked: attr_bool(e.attributes(), b"checked")?,
+                    ..Default::default()
+                };
+                parse_para_pr_body(reader, &mut ps)?;
+                tables.para_shapes.insert(ps.id, ps);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"paraProperties" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <paraProperties>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_para_pr_body<B: BufRead>(reader: &mut Reader<B>, ps: &mut ParaShape) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Empty(e) | Event::Start(e) => {
+                let name = local_name(e.name()).to_vec();
+                let is_start = matches!(ev, Event::Start(_));
+                match name.as_slice() {
+                    b"align" => {
+                        ps.h_align = HAlign::parse(&attr_string(e.attributes(), b"horizontal")?);
+                        ps.v_align = VAlign::parse(&attr_string(e.attributes(), b"vertical")?);
+                    }
+                    b"heading" => {
+                        ps.heading_type =
+                            HeadingType::parse(&attr_string(e.attributes(), b"type")?);
+                        ps.heading_id_ref = attr_u32(e.attributes(), b"idRef")?;
+                        ps.heading_level = attr_u32(e.attributes(), b"level")?;
+                    }
+                    b"breakSetting" => {
+                        ps.break_latin_word =
+                            LineBreakWord::parse(&attr_string(e.attributes(), b"breakLatinWord")?);
+                        ps.break_non_latin_word = LineBreakWord::parse(&attr_string(
+                            e.attributes(),
+                            b"breakNonLatinWord",
+                        )?);
+                        ps.widow_orphan = attr_bool(e.attributes(), b"widowOrphan")?;
+                        ps.keep_with_next = attr_bool(e.attributes(), b"keepWithNext")?;
+                        ps.keep_lines = attr_bool(e.attributes(), b"keepLines")?;
+                        ps.page_break_before = attr_bool(e.attributes(), b"pageBreakBefore")?;
+                        // `lineWrap` is "BREAK"/"KEEP" in HWPX; treat BREAK as true.
+                        ps.line_wrap = attr_string(e.attributes(), b"lineWrap")? == "BREAK";
+                    }
+                    b"autoSpacing" => {
+                        ps.auto_spacing_eng = attr_bool(e.attributes(), b"eAsianEng")?;
+                        ps.auto_spacing_num = attr_bool(e.attributes(), b"eAsianNum")?;
+                    }
+                    b"switch" if is_start => {
+                        parse_para_pr_switch(reader, ps)?;
+                        buf.clear();
+                        continue;
+                    }
+                    b"margin" if is_start => {
+                        ps.margin = parse_margin_body(reader)?;
+                        buf.clear();
+                        continue;
+                    }
+                    b"lineSpacing" => {
+                        ps.line_spacing = parse_line_spacing(e.attributes())?;
+                    }
+                    b"border" => {
+                        ps.border_fill_id_ref = attr_u32(e.attributes(), b"borderFillIDRef")?;
+                        ps.border_offset_left = attr_i32(e.attributes(), b"offsetLeft")?;
+                        ps.border_offset_right = attr_i32(e.attributes(), b"offsetRight")?;
+                        ps.border_offset_top = attr_i32(e.attributes(), b"offsetTop")?;
+                        ps.border_offset_bottom = attr_i32(e.attributes(), b"offsetBottom")?;
+                        ps.connect = attr_bool(e.attributes(), b"connect")?;
+                        ps.ignore_margin = attr_bool(e.attributes(), b"ignoreMargin")?;
+                    }
+                    _ => {}
+                }
+                if is_start {
+                    skip(reader, e)?;
+                }
+            }
+            Event::End(e) if local_name(e.name()) == b"paraPr" => return Ok(()),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <paraPr>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// The `<hp:switch>` inside a `<hh:paraPr>` contains the margin +
+/// lineSpacing in both "HwpUnitChar-required" and default namespaces.
+/// The reference's `RParaShape` consumes the `<hp:case required-namespace=
+/// ".../HwpUnitChar">` branch. We take the first `<margin>` and
+/// `<lineSpacing>` we encounter — that is the `<hp:case>` branch in
+/// every HWPX in-the-wild — and ignore the rest.
+fn parse_para_pr_switch<B: BufRead>(reader: &mut Reader<B>, ps: &mut ParaShape) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    let mut got_margin = false;
+    let mut got_line_spacing = false;
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Start(e) => match local_name(e.name()) {
+                b"margin" => {
+                    if !got_margin {
+                        ps.margin = parse_margin_body(reader)?;
+                        got_margin = true;
+                    } else {
+                        skip(reader, e)?;
+                    }
+                }
+                _ => {
+                    // `<hp:case>` or `<hp:default>` wrappers, or any
+                    // other nested element — fall through so that the
+                    // inner <margin>/<lineSpacing> are reachable as
+                    // subsequent events.
+                }
+            },
+            Event::Empty(e) if local_name(e.name()) == b"lineSpacing" && !got_line_spacing => {
+                ps.line_spacing = parse_line_spacing(e.attributes())?;
+                got_line_spacing = true;
+            }
+            Event::Empty(_) => {}
+            Event::End(e) if local_name(e.name()) == b"switch" => return Ok(()),
+            Event::Eof => {
+                return Err(DvcError::Document(
+                    "unexpected EOF inside <paraPr switch>".into(),
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_margin_body<B: BufRead>(reader: &mut Reader<B>) -> DvcResult<Margin> {
+    let mut buf = Vec::new();
+    let mut m = Margin::default();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match &ev {
+            Event::Empty(e) | Event::Start(e) => {
+                let name = local_name(e.name());
+                let is_start = matches!(ev, Event::Start(_));
+                let v = attr_i32(e.attributes(), b"value")?;
+                match name {
+                    b"intent" | b"indent" => m.indent = v,
+                    b"left" => m.left = v,
+                    b"right" => m.right = v,
+                    b"prev" => m.prev = v,
+                    b"next" => m.next = v,
+                    _ => {}
+                }
+                if is_start {
+                    skip(reader, e)?;
+                }
+            }
+            Event::End(e) if local_name(e.name()) == b"margin" => return Ok(m),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <margin>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+fn parse_line_spacing(attrs: Attributes<'_>) -> DvcResult<LineSpacing> {
+    Ok(LineSpacing {
+        type_: LineSpacingType::parse(&attr_string(attrs.clone(), b"type")?),
+        value: attr_i32(attrs.clone(), b"value")?,
+        unit: attr_string(attrs, b"unit")?,
+    })
+}

--- a/crates/hwp-dvc-core/src/document/header/types/enums.rs
+++ b/crates/hwp-dvc-core/src/document/header/types/enums.rs
@@ -1,0 +1,293 @@
+//! Attribute-decoding enums and the small `LangTuple<T>` helper.
+//!
+//! Each enum carries a `parse(&str) -> Self` (or `Option<Self>` for
+//! `FontLang`) that maps OWPML's all-caps tokens to variants. Unknown
+//! tokens map to `::Other` rather than panicking — HWPX has shipped
+//! multiple minor revisions with new tokens.
+
+use serde::{Deserialize, Serialize};
+
+/// The seven OWPML font language slots, in declaration order.
+///
+/// Each `<hh:charPr>` carries a per-language tuple (`hangul`, `latin`,
+/// `hanja`, `japanese`, `other`, `symbol`, `user`); the reference
+/// collapses this to `Hangul` only. We preserve all seven so that the
+/// later validators (`CheckCharShape`) can report which slot violated a
+/// rule.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FontLang {
+    #[default]
+    Hangul,
+    Latin,
+    Hanja,
+    Japanese,
+    Other,
+    Symbol,
+    User,
+}
+
+impl FontLang {
+    pub const ALL: [FontLang; 7] = [
+        FontLang::Hangul,
+        FontLang::Latin,
+        FontLang::Hanja,
+        FontLang::Japanese,
+        FontLang::Other,
+        FontLang::Symbol,
+        FontLang::User,
+    ];
+
+    /// Parse the OWPML `lang=".."` attribute of `<hh:fontface>`.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "HANGUL" => Some(Self::Hangul),
+            "LATIN" => Some(Self::Latin),
+            "HANJA" => Some(Self::Hanja),
+            "JAPANESE" => Some(Self::Japanese),
+            "OTHER" => Some(Self::Other),
+            "SYMBOL" => Some(Self::Symbol),
+            "USER" => Some(Self::User),
+            _ => None,
+        }
+    }
+
+    pub fn index(self) -> usize {
+        match self {
+            Self::Hangul => 0,
+            Self::Latin => 1,
+            Self::Hanja => 2,
+            Self::Japanese => 3,
+            Self::Other => 4,
+            Self::Symbol => 5,
+            Self::User => 6,
+        }
+    }
+}
+
+/// Per-language `u32` / `i32` tuple. Default is all zeros.
+///
+/// Parsed from attributes like
+/// `<hh:fontRef hangul="1" latin="0" .../>`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LangTuple<T: Copy + Default> {
+    pub values: [T; 7],
+}
+
+impl<T: Copy + Default> LangTuple<T> {
+    pub fn get(&self, lang: FontLang) -> T {
+        self.values[lang.index()]
+    }
+
+    pub fn set(&mut self, lang: FontLang, v: T) {
+        self.values[lang.index()] = v;
+    }
+}
+
+/// Line-type for cell borders (`<hh:leftBorder type="..." .../>`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum LineType {
+    #[default]
+    None,
+    Solid,
+    Dash,
+    Dot,
+    DashDot,
+    DashDotDot,
+    LongDash,
+    Circle,
+    DoubleSlim,
+    SlimThick,
+    ThickSlim,
+    SlimThickSlim,
+    Wave,
+    DoubleWave,
+    ThickThreeD,
+    ThickThreeDInset,
+    ThinThreeD,
+    ThinThreeDInset,
+    /// Unrecognized value carried forward for debugging.
+    Other,
+}
+
+impl LineType {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "NONE" => Self::None,
+            "SOLID" => Self::Solid,
+            "DASH" => Self::Dash,
+            "DOT" => Self::Dot,
+            "DASH_DOT" => Self::DashDot,
+            "DASH_DOT_DOT" => Self::DashDotDot,
+            "LONG_DASH" => Self::LongDash,
+            "CIRCLE" => Self::Circle,
+            "DOUBLE_SLIM" => Self::DoubleSlim,
+            "SLIM_THICK" => Self::SlimThick,
+            "THICK_SLIM" => Self::ThickSlim,
+            "SLIM_THICK_SLIM" => Self::SlimThickSlim,
+            "WAVE" => Self::Wave,
+            "DOUBLE_WAVE" => Self::DoubleWave,
+            "THICK_3D" => Self::ThickThreeD,
+            "THICK_3D_INSET" => Self::ThickThreeDInset,
+            "THIN_3D" => Self::ThinThreeD,
+            "THIN_3D_INSET" => Self::ThinThreeDInset,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Horizontal alignment (`<hh:align horizontal="..."/>`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum HAlign {
+    #[default]
+    Justify,
+    Left,
+    Right,
+    Center,
+    Distribute,
+    DistributeSpace,
+    Other,
+}
+
+impl HAlign {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "JUSTIFY" => Self::Justify,
+            "LEFT" => Self::Left,
+            "RIGHT" => Self::Right,
+            "CENTER" => Self::Center,
+            "DISTRIBUTE" => Self::Distribute,
+            "DISTRIBUTE_SPACE" => Self::DistributeSpace,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Vertical alignment (`<hh:align vertical="..."/>`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum VAlign {
+    #[default]
+    Baseline,
+    Top,
+    Center,
+    Bottom,
+    Other,
+}
+
+impl VAlign {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "BASELINE" => Self::Baseline,
+            "TOP" => Self::Top,
+            "CENTER" => Self::Center,
+            "BOTTOM" => Self::Bottom,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Heading type (`<hh:heading type="..."/>`): outline / number / bullet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum HeadingType {
+    #[default]
+    None,
+    Outline,
+    Number,
+    Bullet,
+    Other,
+}
+
+impl HeadingType {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "NONE" => Self::None,
+            "OUTLINE" => Self::Outline,
+            "NUMBER" => Self::Number,
+            "BULLET" => Self::Bullet,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Line-break behavior for latin and non-latin words.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum LineBreakWord {
+    #[default]
+    KeepWord,
+    BreakWord,
+    Other,
+}
+
+impl LineBreakWord {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "KEEP_WORD" => Self::KeepWord,
+            "BREAK_WORD" => Self::BreakWord,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Spacing type for `<hh:lineSpacing type="..."/>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum LineSpacingType {
+    #[default]
+    Percent,
+    Fixed,
+    BetweenLines,
+    Minimum,
+    Other,
+}
+
+impl LineSpacingType {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "PERCENT" => Self::Percent,
+            "FIXED" => Self::Fixed,
+            "BETWEEN_LINES" => Self::BetweenLines,
+            "AT_LEAST" | "MINIMUM" => Self::Minimum,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_lang_parses_all_seven() {
+        assert_eq!(FontLang::parse("HANGUL"), Some(FontLang::Hangul));
+        assert_eq!(FontLang::parse("LATIN"), Some(FontLang::Latin));
+        assert_eq!(FontLang::parse("HANJA"), Some(FontLang::Hanja));
+        assert_eq!(FontLang::parse("JAPANESE"), Some(FontLang::Japanese));
+        assert_eq!(FontLang::parse("OTHER"), Some(FontLang::Other));
+        assert_eq!(FontLang::parse("SYMBOL"), Some(FontLang::Symbol));
+        assert_eq!(FontLang::parse("USER"), Some(FontLang::User));
+        assert_eq!(FontLang::parse("unknown"), None);
+        assert_eq!(FontLang::parse(""), None);
+    }
+
+    #[test]
+    fn font_lang_indices_are_contiguous() {
+        for (i, &lang) in FontLang::ALL.iter().enumerate() {
+            assert_eq!(lang.index(), i);
+        }
+    }
+
+    #[test]
+    fn line_type_parses_common_values() {
+        assert_eq!(LineType::parse("NONE"), LineType::None);
+        assert_eq!(LineType::parse("SOLID"), LineType::Solid);
+        assert_eq!(LineType::parse("DASH"), LineType::Dash);
+        assert_eq!(LineType::parse("SLIM_THICK_SLIM"), LineType::SlimThickSlim);
+        assert_eq!(LineType::parse("THICK_3D"), LineType::ThickThreeD);
+        assert_eq!(LineType::parse("SOMETHING_ELSE"), LineType::Other);
+    }
+}

--- a/crates/hwp-dvc-core/src/document/header/types/mod.rs
+++ b/crates/hwp-dvc-core/src/document/header/types/mod.rs
@@ -1,0 +1,35 @@
+//! Typed header-table structs for OWPML `Contents/header.xml`.
+//!
+//! The shape set here mirrors the reference C++ (`RCharShape`,
+//! `RParaShape`, `RTable` border-fill portion, `RBullets`,
+//! `ROutlineShape`) closely enough to drive the Phase 2 validators,
+//! while flattening awkward language-split structures into a single
+//! seven-entry array indexed by [`FontLang`].
+//!
+//! Integers that the reference declares as `UINT` are kept as `u32`
+//! here. Signed fields stay `i32`. Booleans are `bool`. Enum-like
+//! attributes (`LINETYPE2`, `ParaType`, `HAlignType`, …) are decoded
+//! into dedicated Rust enums with a fallible `parse` constructor so
+//! that unknown values in future HWPX revisions can be flagged without
+//! a crash.
+//!
+//! Every record carries its integer `id` (`charPrID`, `paraPrID`,
+//! `borderFillId`, `styleId`, `bulletId`, `numberingId`) so that
+//! downstream validators can re-emit it in error messages.
+//!
+//! # Module layout
+//!
+//! - [`enums`] — `FontLang` and the attribute-decoding enums plus the
+//!   tiny `LangTuple<T>` helper.
+//! - [`shapes`] — the struct records and their impls.
+
+pub mod enums;
+pub mod shapes;
+
+pub use enums::{
+    FontLang, HAlign, HeadingType, LangTuple, LineBreakWord, LineSpacingType, LineType, VAlign,
+};
+pub use shapes::{
+    Border, BorderFill, Bullet, CharShape, FontFace, LineSpacing, Margin, Numbering, ParaHead,
+    ParaShape, Style,
+};

--- a/crates/hwp-dvc-core/src/document/header/types/shapes.rs
+++ b/crates/hwp-dvc-core/src/document/header/types/shapes.rs
@@ -1,0 +1,311 @@
+//! Struct records for each OWPML header table.
+
+use std::collections::HashMap;
+
+use super::enums::{
+    FontLang, HAlign, HeadingType, LangTuple, LineBreakWord, LineSpacingType, LineType, VAlign,
+};
+
+/// Resolved font table: for each of the seven language slots, an
+/// `id -> face` mapping. The `id` matches the value of
+/// `charPr.font_ref[lang]`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FontFace {
+    pub lang: FontLang,
+    pub fonts: HashMap<u32, String>,
+}
+
+/// A character-shape record (`<hh:charPr>`).
+///
+/// Fields track what Phase 2 `CheckCharShape` needs: font references
+/// per language, ratio/spacing/rel-size/offset per language,
+/// height (0.1 pt units), text/shade colors, and the boolean emphasis
+/// flags (bold/italic/…).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CharShape {
+    pub id: u32,
+    pub height: u32,
+    pub text_color: String,
+    pub shade_color: String,
+    pub use_font_space: bool,
+    pub use_kerning: bool,
+    pub sym_mark: String,
+    pub border_fill_id_ref: u32,
+
+    pub font_ref: LangTuple<u32>,
+    pub ratio: LangTuple<u32>,
+    pub spacing: LangTuple<i32>,
+    pub rel_sz: LangTuple<u32>,
+    pub offset: LangTuple<i32>,
+
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub strikeout: bool,
+    pub outline: bool,
+    pub emboss: bool,
+    pub engrave: bool,
+    pub shadow: bool,
+    pub supscript: bool,
+    pub subscript: bool,
+}
+
+impl CharShape {
+    /// Resolve the font name of this char-shape for a given language,
+    /// consulting the supplied font-face table.
+    pub fn font_name<'a>(&self, lang: FontLang, faces: &'a [FontFace]) -> Option<&'a str> {
+        let id = self.font_ref.get(lang);
+        faces
+            .iter()
+            .find(|f| f.lang == lang)
+            .and_then(|f| f.fonts.get(&id).map(String::as_str))
+    }
+
+    /// Collect font names across all seven language slots, deduplicated
+    /// while preserving first-seen order. Useful for the Phase 2 font
+    /// allow-list check as well as for the fixture test that asserts
+    /// the default font is `함초롬바탕`.
+    pub fn font_names(&self, faces: &[FontFace]) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for &lang in &FontLang::ALL {
+            if let Some(name) = self.font_name(lang, faces) {
+                if !out.iter().any(|n| n == name) {
+                    out.push(name.to_string());
+                }
+            }
+        }
+        out
+    }
+}
+
+/// A single border edge of a [`BorderFill`].
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Border {
+    pub line_type: LineType,
+    /// The `width` attribute is emitted as e.g. `"0.12 mm"`; we strip
+    /// the unit suffix and keep the mm value as `f32` so that validators
+    /// can compare against the spec-supplied floating-point threshold.
+    pub width_mm: f32,
+    pub color: String,
+}
+
+/// A `<hh:borderFill>` record. Only the fields the validators need are
+/// decoded; `<hc:fillBrush>` subtrees are tracked as "present or not"
+/// because `CheckTable` only needs to know that a fill was supplied, not
+/// the exact brush.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BorderFill {
+    pub id: u32,
+    pub three_d: bool,
+    pub shadow: bool,
+    pub center_line: String,
+    pub break_cell_separate_line: bool,
+
+    pub left: Border,
+    pub right: Border,
+    pub top: Border,
+    pub bottom: Border,
+    pub diagonal: Border,
+
+    pub has_fill_brush: bool,
+}
+
+impl BorderFill {
+    /// True iff left, right, top, bottom are all `Solid`.
+    pub fn four_sides_solid(&self) -> bool {
+        self.left.line_type == LineType::Solid
+            && self.right.line_type == LineType::Solid
+            && self.top.line_type == LineType::Solid
+            && self.bottom.line_type == LineType::Solid
+    }
+}
+
+/// `<hh:lineSpacing type="..." value=".." unit=".."/>`.
+///
+/// Not `Copy` because `unit` is a `String`; the header is parsed once
+/// per document and `LineSpacing` values are cloned only when a
+/// validator wants to surface one in an error message, so the cost is
+/// negligible.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LineSpacing {
+    pub type_: LineSpacingType,
+    pub value: i32,
+    pub unit: String,
+}
+
+/// Paragraph margin in HWPUNIT (1 HWPUNIT = 1/7200 inch), matching the
+/// reference's `Margin` struct but omitting the per-case / default
+/// `<hp:switch>` wrapper. We decode the first (`hp:case`) branch —
+/// which is what HWPX emitters consistently populate — and leave
+/// alternate-namespace handling to a later pass when a concrete test
+/// case exposes a divergence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Margin {
+    pub indent: i32,
+    pub left: i32,
+    pub right: i32,
+    pub prev: i32,
+    pub next: i32,
+}
+
+/// A paragraph-shape record (`<hh:paraPr>`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParaShape {
+    pub id: u32,
+    pub tab_pr_id_ref: u32,
+    pub condense: u32,
+    pub font_line_height: bool,
+    pub snap_to_grid: bool,
+    pub suppress_line_numbers: bool,
+    pub checked: bool,
+
+    pub h_align: HAlign,
+    pub v_align: VAlign,
+
+    pub heading_type: HeadingType,
+    pub heading_id_ref: u32,
+    pub heading_level: u32,
+
+    pub break_latin_word: LineBreakWord,
+    pub break_non_latin_word: LineBreakWord,
+
+    pub widow_orphan: bool,
+    pub keep_with_next: bool,
+    pub keep_lines: bool,
+    pub page_break_before: bool,
+    pub line_wrap: bool,
+
+    pub auto_spacing_eng: bool,
+    pub auto_spacing_num: bool,
+
+    pub margin: Margin,
+    pub line_spacing: LineSpacing,
+
+    pub border_fill_id_ref: u32,
+    pub border_offset_left: i32,
+    pub border_offset_right: i32,
+    pub border_offset_top: i32,
+    pub border_offset_bottom: i32,
+    pub connect: bool,
+    pub ignore_margin: bool,
+}
+
+/// A `<hh:style>` record. Both `PARA` and `CHAR` style types live in the
+/// same table (keyed by `id`); `style_type` distinguishes them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Style {
+    pub id: u32,
+    pub style_type: String,
+    pub name: String,
+    pub eng_name: String,
+    pub para_pr_id_ref: u32,
+    pub char_pr_id_ref: u32,
+    pub next_style_id_ref: u32,
+    pub lang_id: u32,
+    pub lock_form: bool,
+}
+
+/// A `<hh:bullet>` record. The character payload is the literal bullet
+/// glyph (e.g. `"□"`, `"○"`, …). Image bullets are not decoded here but
+/// their `use_image=1` flag is preserved.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Bullet {
+    pub id: u32,
+    pub char: String,
+    pub use_image: bool,
+}
+
+/// A numbering template level (`<hh:paraHead>`). Mirrors the reference's
+/// `ParaHead` but keeps numeric enums as raw strings, because the
+/// Phase 2 validators compare these to spec strings unmodified.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParaHead {
+    pub start: u32,
+    pub level: u32,
+    pub align: String,
+    pub use_inst_width: bool,
+    pub auto_indent: bool,
+    pub width_adjust: bool,
+    pub text_offset_type: String,
+    pub text_offset: u32,
+    pub num_format: String,
+    pub char_pr_id_ref: u32,
+    pub checkable: bool,
+    pub num_format_text: String,
+}
+
+/// A `<hh:numbering>` record: one template per level (up to 10 in
+/// practice). Levels are not guaranteed contiguous in the XML, so we
+/// keep them in the declaration order they appeared.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Numbering {
+    pub id: u32,
+    pub start: u32,
+    pub para_heads: Vec<ParaHead>,
+}
+
+impl Numbering {
+    pub fn by_level(&self, level: u32) -> Option<&ParaHead> {
+        self.para_heads.iter().find(|p| p.level == level)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_sides_solid_detects_all_solid_correctly() {
+        let mut bf = BorderFill::default();
+        assert!(!bf.four_sides_solid(), "default is None, not Solid");
+        bf.left.line_type = LineType::Solid;
+        bf.right.line_type = LineType::Solid;
+        bf.top.line_type = LineType::Solid;
+        assert!(!bf.four_sides_solid(), "only three sides Solid");
+        bf.bottom.line_type = LineType::Solid;
+        assert!(bf.four_sides_solid(), "all four sides Solid");
+        bf.bottom.line_type = LineType::Dash;
+        assert!(!bf.four_sides_solid(), "bottom became Dash");
+    }
+
+    #[test]
+    fn char_shape_font_names_dedups_while_preserving_order() {
+        let mut face = FontFace {
+            lang: FontLang::Hangul,
+            fonts: HashMap::new(),
+        };
+        face.fonts.insert(0, "Hamcho".into());
+        face.fonts.insert(1, "Nanum".into());
+        let faces = vec![
+            face,
+            FontFace {
+                lang: FontLang::Latin,
+                fonts: {
+                    let mut m = HashMap::new();
+                    m.insert(0, "Hamcho".into());
+                    m
+                },
+            },
+        ];
+        let cs = CharShape {
+            id: 0,
+            font_ref: {
+                let mut t = LangTuple::<u32>::default();
+                t.set(FontLang::Hangul, 1);
+                t.set(FontLang::Latin, 0);
+                t
+            },
+            ..Default::default()
+        };
+        let names = cs.font_names(&faces);
+        // Hangul→Nanum, Latin→Hamcho, rest default to id=0 in Hangul
+        // face which maps to Hamcho — so Hamcho should appear exactly
+        // once.
+        assert_eq!(
+            names.iter().filter(|n| n.as_str() == "Hamcho").count(),
+            1,
+            "Hamcho must be deduplicated"
+        );
+        assert!(names.contains(&"Nanum".to_string()));
+    }
+}

--- a/crates/hwp-dvc-core/src/document/mod.rs
+++ b/crates/hwp-dvc-core/src/document/mod.rs
@@ -15,13 +15,17 @@
 //! The reference C++ implementation delegates this to Hancom's OWPML
 //! model DLL. In Rust we parse the XML directly with `quick-xml`.
 //!
-//! This module currently only opens the archive and lists contained
-//! parts; full OWPML parsing is tracked separately.
+//! The `header` submodule is live; body section parsing is tracked
+//! separately (issue #3).
+
+pub mod header;
 
 use std::io::Read;
 use std::path::Path;
 
 use crate::error::{DvcError, DvcResult};
+
+pub use header::HeaderTables;
 
 /// A minimal HWPX archive handle.
 ///
@@ -64,6 +68,18 @@ impl HwpxArchive {
     pub fn part(&self, name: &str) -> Option<&Part> {
         self.parts.iter().find(|p| p.name == name)
     }
+
+    /// Parse `Contents/header.xml` from this archive.
+    ///
+    /// Returns [`DvcError::Document`] if the archive has no
+    /// `Contents/header.xml` part, or [`DvcError::Xml`] if the part's
+    /// bytes fail to parse.
+    pub fn read_header(&self) -> DvcResult<HeaderTables> {
+        let part = self
+            .part("Contents/header.xml")
+            .ok_or_else(|| DvcError::Document("missing Contents/header.xml".into()))?;
+        header::parser::parse_header(&part.bytes)
+    }
 }
 
 /// Placeholder result of parsing the OWPML document — to be fleshed
@@ -96,7 +112,10 @@ pub struct RunTypeInfo {
 impl Document {
     pub fn open(path: impl AsRef<Path>) -> DvcResult<Self> {
         let archive = HwpxArchive::open(path)?;
-        Ok(Self { archive, run_type_infos: Vec::new() })
+        Ok(Self {
+            archive,
+            run_type_infos: Vec::new(),
+        })
     }
 
     /// Parse the OWPML body into `RunTypeInfo` entries.

--- a/crates/hwp-dvc-core/tests/header_parsing.rs
+++ b/crates/hwp-dvc-core/tests/header_parsing.rs
@@ -1,0 +1,193 @@
+//! Integration tests for `HwpxArchive::read_header()` against real
+//! HWPX fixtures committed under `tests/fixtures/docs/`.
+//!
+//! Each test opens a fixture end-to-end, parses its `Contents/header.xml`,
+//! and asserts a concrete domain fact — never just "it didn't panic".
+//! Fixture assignment matches the Epic #1 integration-test table:
+//!
+//! | Fixture              | Assertion                                         |
+//! |----------------------|---------------------------------------------------|
+//! | `charshape_pass`     | default CharShape resolves to `함초롬바탕`.       |
+//! | `table_nested`       | at least one `BorderFill` has 4 `SOLID` sides.    |
+//! | `style_custom`       | user-defined style `"테스트스타일"` is present.   |
+//!
+//! The spec paired with these fixtures is
+//! `tests/fixtures/specs/fixture_spec.json`; the spec is not loaded in
+//! these tests (spec wiring is in the checker tests), but the spec
+//! listing is what ties fixture choice to this issue.
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::document::header::{FontLang, HeaderTables};
+use hwp_dvc_core::document::HwpxArchive;
+
+/// Absolute path to a fixture under `tests/fixtures/docs/`.
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("docs");
+    p.push(name);
+    p
+}
+
+fn load_header(name: &str) -> HeaderTables {
+    let archive = HwpxArchive::open(fixture(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    archive
+        .read_header()
+        .unwrap_or_else(|e| panic!("failed to parse {name}/Contents/header.xml: {e}"))
+}
+
+#[test]
+fn charshape_pass_header_has_hamcho_font() {
+    let tables = load_header("charshape_pass.hwpx");
+
+    // Baseline sanity.
+    assert!(
+        !tables.char_shapes.is_empty(),
+        "charshape_pass must expose at least one charShape"
+    );
+    assert!(
+        !tables.font_faces.is_empty(),
+        "charshape_pass must expose at least one fontface"
+    );
+
+    // The charshape_pass fixture is the HWP default (fixture_spec.json
+    // baseline): every CharShape's Hangul font must ultimately resolve
+    // to 함초롬바탕. At least one CharShape must list that font name in
+    // its resolved face set.
+    let has_hamcho = tables.char_shapes.values().any(|cs| {
+        cs.font_names(&tables.font_faces)
+            .iter()
+            .any(|n| n == "함초롬바탕")
+    });
+
+    assert!(
+        has_hamcho,
+        "expected at least one CharShape whose font names contain '함초롬바탕'; \
+         got charshape font sets: {:?}",
+        tables
+            .char_shapes
+            .values()
+            .map(|cs| cs.font_names(&tables.font_faces))
+            .collect::<Vec<_>>()
+    );
+
+    // Spot-check the FontLang::Hangul slot of CharShape id=0 (the
+    // default `바탕글` style's charPr). The declared font id for Hangul
+    // at id=0 is `1` in the fixture, and font id 1 in the HANGUL
+    // fontface resolves to 함초롬바탕.
+    let hangul_font_of_default = tables.font_name(0, FontLang::Hangul);
+    assert_eq!(
+        hangul_font_of_default,
+        Some("함초롬바탕"),
+        "default CharShape's Hangul font must be 함초롬바탕"
+    );
+}
+
+#[test]
+fn table_nested_header_has_border_fills() {
+    let tables = load_header("table_nested.hwpx");
+
+    assert!(
+        !tables.border_fills.is_empty(),
+        "table_nested must declare border-fill entries for its table cells"
+    );
+
+    // The `table_nested.hwpx` fixture is authored with
+    // `실선 0.12mm 검정` on the table's four outer borders. A BorderFill
+    // with all four sides SOLID must therefore be present.
+    let has_four_solid = tables.border_fills.values().any(|bf| bf.four_sides_solid());
+
+    assert!(
+        has_four_solid,
+        "expected at least one BorderFill with all four sides SOLID; got: {:?}",
+        tables
+            .border_fills
+            .values()
+            .map(|bf| (
+                bf.id,
+                bf.left.line_type,
+                bf.right.line_type,
+                bf.top.line_type,
+                bf.bottom.line_type
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn style_custom_header_has_user_style() {
+    let tables = load_header("style_custom.hwpx");
+
+    assert!(
+        !tables.styles.is_empty(),
+        "style_custom must declare at least one style"
+    );
+
+    let custom = tables.style_by_name("테스트스타일");
+    assert!(
+        custom.is_some(),
+        "expected a user-defined style named '테스트스타일'; got styles: {:?}",
+        tables
+            .styles
+            .values()
+            .map(|s| (s.id, s.name.clone(), s.style_type.clone()))
+            .collect::<Vec<_>>()
+    );
+
+    let style = custom.unwrap();
+    assert_eq!(style.name, "테스트스타일");
+    // The fixture README (tests/fixtures/docs/README.md) specifies that
+    // `테스트스타일` is defined as a PARA-type style based on 바탕글.
+    assert_eq!(
+        style.style_type, "PARA",
+        "테스트스타일 must be a PARA-type style"
+    );
+
+    // 바탕글 (the built-in default) must also still exist.
+    assert!(
+        tables.style_by_name("바탕글").is_some(),
+        "built-in 바탕글 style must coexist with the user-defined style"
+    );
+}
+
+#[test]
+fn charshape_pass_tables_populated_across_categories() {
+    // Broader sanity check covering every HeaderTables bucket. Keeps
+    // regressions that silently drop a whole category from sneaking in.
+    let tables = load_header("charshape_pass.hwpx");
+
+    assert!(
+        !tables.char_shapes.is_empty(),
+        "char_shapes must be populated"
+    );
+    assert!(
+        !tables.para_shapes.is_empty(),
+        "para_shapes must be populated"
+    );
+    assert!(
+        !tables.border_fills.is_empty(),
+        "border_fills must be populated"
+    );
+    assert!(!tables.styles.is_empty(), "styles must be populated");
+    assert!(
+        tables.style_by_name("바탕글").is_some(),
+        "default 바탕글 style must be present"
+    );
+    // numberings are optional per document but the baseline fixture
+    // includes them, so we still assert them:
+    assert!(
+        !tables.numberings.is_empty(),
+        "numberings must be populated in the baseline fixture"
+    );
+
+    // Seven font-face slots are always declared by Hancom writers, one
+    // per FontLang.
+    assert_eq!(
+        tables.font_faces.len(),
+        7,
+        "HWPX writers emit one fontface per FontLang"
+    );
+}


### PR DESCRIPTION
## Summary
Port the Phase 1a piece of Epic #1: a `quick-xml`-driven parser for `Contents/header.xml` that produces a `HeaderTables` struct with six ID-keyed maps (charShape, paraShape, borderFill, style, bullet, numbering) plus the seven-slot fontface table. Exposed via `HwpxArchive::read_header() -> DvcResult<HeaderTables>`. `Document::parse()` (section walker) is untouched — that lands in #3.

## Acceptance criteria (from #2)
- [x] New module `document::header` with a `HeaderTables` struct exposing `char_shapes: HashMap<u32, CharShape>`, `para_shapes: HashMap<u32, ParaShape>`, `border_fills: HashMap<u32, BorderFill>`, `styles: HashMap<u32, Style>`, `bullets: HashMap<u32, Bullet>`, `numberings: HashMap<u32, Numbering>`.
- [x] Field set per shape type matches the reference enough to drive Phase 2 validators.
- [x] `HwpxArchive::read_header() -> DvcResult<HeaderTables>` using `quick-xml`.
- [x] Unit tests against a small hand-crafted `header.xml` fixture.
- [x] Integration tests against real HWPX fixtures per Epic #1 constraint.

## Integration tests
`crates/hwp-dvc-core/tests/header_parsing.rs` loads the fixtures the Epic #1 table pins to this issue and asserts concrete behaviours:

| Fixture                           | Assertion                                                        |
|-----------------------------------|------------------------------------------------------------------|
| `charshape_pass.hwpx`             | default CharShape resolves to `함초롬바탕`; all six tables populated. |
| `table_nested.hwpx`               | `border_fills` has at least one entry with all four sides `SOLID`. |
| `style_custom.hwpx`               | user-defined style `테스트스타일` (PARA) coexists with built-in `바탕글`. |

## Notes on the port
- Per-language font/ratio/spacing tuples are preserved as all seven `FontLang` slots (the reference C++ collapses to `Hangul` only). `CharShape::font_names` deduplicates while preserving order, letting `CheckCharShape` later report which slot violated the allow-list.
- Unknown enum tokens decode to `::Other` instead of erroring — Hancom has already shipped revisions that added new tokens without bumping `version`.
- `<hp:switch>` inside `<hh:paraPr>` is special-cased: we take the first `<margin>` + `<lineSpacing>` we encounter (the `<hp:case required-namespace=".../HwpUnitChar">` branch) matching the reference's behaviour.
- File layout splits `parser/` into one module per top-level element group and `types/` into `enums` + `shapes` so no single file exceeds 320 lines.

## Test plan
- [x] `cargo test --workspace` — 17 tests pass (10 unit + 4 header integration + 3 pre-existing spec-fixture tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Closes #2 · Part of #1