### PR TITLE
feat: port OWPML section parser (closes #3)

### DIFF
--- a/crates/hwp-dvc-core/src/document/mod.rs
+++ b/crates/hwp-dvc-core/src/document/mod.rs
@@ -15,10 +15,12 @@
 //! The reference C++ implementation delegates this to Hancom's OWPML
 //! model DLL. In Rust we parse the XML directly with `quick-xml`.
 //!
-//! The `header` submodule is live; body section parsing is tracked
-//! separately (issue #3).
+//! Submodules:
+//! - [`header`] — `Contents/header.xml` shape tables (issue #2).
+//! - [`section`] — `Contents/section*.xml` paragraph AST (issue #3).
 
 pub mod header;
+pub mod section;
 
 use std::io::Read;
 use std::path::Path;
@@ -26,6 +28,7 @@ use std::path::Path;
 use crate::error::{DvcError, DvcResult};
 
 pub use header::HeaderTables;
+pub use section::Section;
 
 /// A minimal HWPX archive handle.
 ///
@@ -80,6 +83,50 @@ impl HwpxArchive {
             .ok_or_else(|| DvcError::Document("missing Contents/header.xml".into()))?;
         header::parser::parse_header(&part.bytes)
     }
+
+    /// Parse every `Contents/sectionN.xml` part in ascending numeric
+    /// order and return one [`Section`] per part.
+    ///
+    /// Non-numeric suffixes (`Contents/sectionBad.xml`) are silently
+    /// skipped because no conforming HWPX writer produces them; a
+    /// present-but-unnumbered section would be an authoring error
+    /// unrelated to this parser.
+    ///
+    /// Returns an empty vector if the archive declares no section
+    /// parts; that is a documented HWPX edge case (a cover-only
+    /// archive) rather than an error.
+    pub fn read_sections(&self) -> DvcResult<Vec<Section>> {
+        // Collect (index, &Part) pairs, filter to `Contents/sectionN.xml`,
+        // sort by N, then parse in order.
+        let mut numbered: Vec<(u32, &Part)> = Vec::new();
+        for part in &self.parts {
+            if let Some(idx) = section_index(&part.name) {
+                numbered.push((idx, part));
+            }
+        }
+        numbered.sort_by_key(|(idx, _)| *idx);
+
+        let mut sections = Vec::with_capacity(numbered.len());
+        for (idx, part) in numbered {
+            let sec = section::parser::parse_section(idx, &part.bytes).map_err(|e| match e {
+                DvcError::Document(msg) => DvcError::Document(format!("{} in {}", msg, part.name)),
+                other => other,
+            })?;
+            sections.push(sec);
+        }
+        Ok(sections)
+    }
+}
+
+/// Extract the numeric suffix `N` from `Contents/sectionN.xml`.
+/// Returns `None` if the part name does not match that pattern.
+fn section_index(name: &str) -> Option<u32> {
+    let rest = name.strip_prefix("Contents/section")?;
+    let num = rest.strip_suffix(".xml")?;
+    if num.is_empty() {
+        return None;
+    }
+    num.parse::<u32>().ok()
 }
 
 /// Placeholder result of parsing the OWPML document — to be fleshed

--- a/crates/hwp-dvc-core/src/document/section/mod.rs
+++ b/crates/hwp-dvc-core/src/document/section/mod.rs
@@ -1,0 +1,25 @@
+//! OWPML `Contents/section*.xml` parser — body paragraph/run/table AST.
+//!
+//! Each HWPX archive holds one or more `Contents/sectionN.xml` parts.
+//! Each part represents one body section of the document and is a
+//! tree of paragraphs, runs, and tables with arbitrary table-in-table
+//! nesting. This module walks that tree and produces a typed AST
+//! (see [`types`]) that downstream Phase 1c/Phase 2 code consumes.
+//!
+//! See `references/dvc/Source/OWPMLReader.cpp` and
+//! `references/dvc/Source/RTable.cpp` for the C++ reference walker
+//! this Rust implementation mirrors. The Rust version is simpler
+//! because it doesn't carry layout information (pagination, line
+//! segments) — those are deferred to issue #19.
+//!
+//! # Entry point
+//!
+//! [`super::HwpxArchive::read_sections`] is the one function callers
+//! are expected to use. It locates every `Contents/sectionN.xml`
+//! part inside the archive, parses each in ascending `N` order, and
+//! returns one [`Section`] per part.
+
+pub mod parser;
+pub mod types;
+
+pub use types::{Cell, Paragraph, Row, Run, Section, Table};

--- a/crates/hwp-dvc-core/src/document/section/parser/common.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/common.rs
@@ -1,0 +1,49 @@
+//! Shared helpers for the section-XML parser. A thinner version of
+//! the header parser's `common.rs` — the section walker only needs
+//! string/u32 attribute coercion and element-name extraction.
+
+use quick_xml::events::attributes::{AttrError, Attributes};
+use quick_xml::name::QName;
+
+use crate::error::{DvcError, DvcResult};
+
+/// Wrap a `quick_xml` attribute error into [`DvcError::Document`].
+pub(super) fn xml_err(e: AttrError) -> DvcError {
+    DvcError::Document(format!("bad attribute: {e}"))
+}
+
+/// Return the local part of an element name (the portion after the
+/// `ns:` prefix, e.g. `p` for `hp:p`).
+pub(super) fn local_name<'a>(n: QName<'a>) -> &'a [u8] {
+    n.local_name().into_inner()
+}
+
+pub(super) fn attr_str(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<Option<String>> {
+    for a in attrs {
+        let a = a.map_err(xml_err)?;
+        if local_name(a.key) == key {
+            let v = a
+                .unescape_value()
+                .map_err(|e| DvcError::Document(format!("attr decode: {e}")))?;
+            return Ok(Some(v.into_owned()));
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn attr_u32(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<u32> {
+    match attr_str(attrs, key)? {
+        Some(s) => s.trim().parse::<u32>().map_err(|e| {
+            DvcError::Document(format!(
+                "expected u32 for attribute '{}', got '{}': {e}",
+                String::from_utf8_lossy(key),
+                s
+            ))
+        }),
+        None => Ok(0),
+    }
+}
+
+pub(super) fn attr_string(attrs: Attributes<'_>, key: &[u8]) -> DvcResult<String> {
+    Ok(attr_str(attrs, key)?.unwrap_or_default())
+}

--- a/crates/hwp-dvc-core/src/document/section/parser/mod.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/mod.rs
@@ -1,0 +1,176 @@
+//! Event-driven parser for `Contents/section*.xml`.
+//!
+//! The parser matches on XML local names so that the HWPX `hp:`
+//! namespace prefix is transparent — consistent with the header
+//! parser. Unknown elements are skipped with `Reader::read_to_end_into`
+//! so that new attributes or children added by a future writer
+//! revision do not break the walker.
+//!
+//! The walker is split across one file per node kind so that no file
+//! exceeds the project's 500-line soft cap:
+//!
+//! | file | responsibility |
+//! |------|----------------|
+//! | `common.rs` | attribute/name helpers |
+//! | `section.rs` | top-level `<hs:sec>` dispatcher |
+//! | `paragraph.rs` | `<hp:p>` + `<hp:run>` + `<hp:t>` |
+//! | `table.rs` | `<hp:tbl>` + `<hp:tr>` + `<hp:tc>` |
+
+mod common;
+mod paragraph;
+mod section;
+mod table;
+
+pub use section::parse_section;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal plain-paragraph section with one paragraph and one
+    /// text-bearing run.
+    const MINI_PLAIN: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+<hp:p id="1" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">
+<hp:run charPrIDRef="0"><hp:t>Hello, world.</hp:t></hp:run>
+</hp:p>
+</hs:sec>"##;
+
+    /// A 1x1 table inside a paragraph's run.
+    const MINI_TABLE: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+<hp:p id="1" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">
+<hp:run charPrIDRef="0">
+<hp:tbl id="100" borderFillIDRef="3" rowCnt="1" colCnt="1">
+<hp:tr>
+<hp:tc borderFillIDRef="3">
+<hp:subList>
+<hp:p id="10" paraPrIDRef="0" styleIDRef="0">
+<hp:run charPrIDRef="0"><hp:t>inside</hp:t></hp:run>
+</hp:p>
+</hp:subList>
+<hp:cellAddr colAddr="0" rowAddr="0"/>
+</hp:tc>
+</hp:tr>
+</hp:tbl>
+</hp:run>
+</hp:p>
+</hs:sec>"##;
+
+    /// A 1x1 table inside a 1x1 table cell — exercises nesting_depth.
+    const MINI_NESTED: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+<hp:p id="1" paraPrIDRef="0" styleIDRef="0">
+<hp:run charPrIDRef="0">
+<hp:tbl id="100" borderFillIDRef="3" rowCnt="1" colCnt="1">
+<hp:tr>
+<hp:tc borderFillIDRef="3">
+<hp:subList>
+<hp:p id="10" paraPrIDRef="0" styleIDRef="0">
+<hp:run charPrIDRef="0">
+<hp:tbl id="200" borderFillIDRef="3" rowCnt="1" colCnt="1">
+<hp:tr>
+<hp:tc borderFillIDRef="3">
+<hp:subList>
+<hp:p id="20" paraPrIDRef="0" styleIDRef="0">
+<hp:run charPrIDRef="0"><hp:t>deep</hp:t></hp:run>
+</hp:p>
+</hp:subList>
+<hp:cellAddr colAddr="0" rowAddr="0"/>
+</hp:tc>
+</hp:tr>
+</hp:tbl>
+</hp:run>
+</hp:p>
+</hp:subList>
+<hp:cellAddr colAddr="0" rowAddr="0"/>
+</hp:tc>
+</hp:tr>
+</hp:tbl>
+</hp:run>
+</hp:p>
+</hs:sec>"##;
+
+    /// A paragraph with a hyperlink fieldBegin/fieldEnd pair.
+    const MINI_HYPERLINK: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+<hp:p id="1" paraPrIDRef="0" styleIDRef="0">
+<hp:run charPrIDRef="0"><hp:t>before </hp:t></hp:run>
+<hp:run charPrIDRef="0"><hp:fieldBegin type="HYPERLINK" name="h1" fieldid="1"/><hp:t>link</hp:t></hp:run>
+<hp:run charPrIDRef="0"><hp:fieldEnd type="HYPERLINK" fieldid="1"/><hp:t> after</hp:t></hp:run>
+</hp:p>
+</hs:sec>"##;
+
+    #[test]
+    fn parses_plain_paragraph_run() {
+        let s = parse_section(0, MINI_PLAIN.as_bytes()).expect("parse ok");
+        assert_eq!(s.paragraphs.len(), 1);
+        let p = &s.paragraphs[0];
+        assert_eq!(p.runs.len(), 1);
+        assert_eq!(p.runs[0].text, "Hello, world.");
+        assert_eq!(p.tables.len(), 0);
+    }
+
+    #[test]
+    fn parses_single_table_at_depth_zero() {
+        let s = parse_section(0, MINI_TABLE.as_bytes()).expect("parse ok");
+        assert_eq!(s.paragraphs.len(), 1);
+        let p = &s.paragraphs[0];
+        assert_eq!(p.tables.len(), 1);
+        let t = &p.tables[0];
+        assert_eq!(t.id, 100);
+        assert_eq!(t.nesting_depth, 0);
+        assert_eq!(t.row_cnt, 1);
+        assert_eq!(t.col_cnt, 1);
+        assert_eq!(t.rows.len(), 1);
+        let cell = &t.rows[0].cells[0];
+        assert_eq!(cell.row, 0);
+        assert_eq!(cell.col, 0);
+        assert_eq!(cell.paragraphs[0].runs[0].text, "inside");
+    }
+
+    #[test]
+    fn parses_nested_table_depth_one() {
+        let s = parse_section(0, MINI_NESTED.as_bytes()).expect("parse ok");
+        // Depth-0 table should be present, and its cell paragraph
+        // must own a depth-1 nested table.
+        let outer = &s.paragraphs[0].tables[0];
+        assert_eq!(outer.nesting_depth, 0);
+        let cell = &outer.rows[0].cells[0];
+        let inner = &cell.paragraphs[0].tables[0];
+        assert_eq!(inner.id, 200);
+        assert_eq!(inner.nesting_depth, 1);
+        assert_eq!(inner.rows[0].cells[0].paragraphs[0].runs[0].text, "deep");
+    }
+
+    #[test]
+    fn detects_hyperlink_marker_runs() {
+        let s = parse_section(0, MINI_HYPERLINK.as_bytes()).expect("parse ok");
+        let p = &s.paragraphs[0];
+        // The first run is before the hyperlink — not flagged.
+        assert!(!p.runs[0].is_hyperlink);
+        // The middle run opens FieldBegin type=HYPERLINK — flagged.
+        assert!(p.runs[1].is_hyperlink);
+        // The trailing run sees FieldEnd — no longer flagged.
+        assert!(!p.runs[2].is_hyperlink);
+    }
+
+    #[test]
+    fn all_tables_yields_nested_depths_in_document_order() {
+        let s = parse_section(0, MINI_NESTED.as_bytes()).expect("parse ok");
+        let depths: Vec<u32> = s.all_tables().map(|t| t.nesting_depth).collect();
+        assert_eq!(depths, vec![0, 1]);
+    }
+
+    #[test]
+    fn all_paragraphs_descends_into_cells() {
+        let s = parse_section(0, MINI_NESTED.as_bytes()).expect("parse ok");
+        // The document has 3 paragraphs in total: top-level (id=1),
+        // inside outer cell (id=10), inside inner cell (id=20).
+        assert_eq!(s.all_paragraphs().count(), 3);
+    }
+}

--- a/crates/hwp-dvc-core/src/document/section/parser/paragraph.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/paragraph.rs
@@ -1,0 +1,193 @@
+//! `<hp:p>` and `<hp:run>` walker.
+//!
+//! OWPML paragraphs contain one or more `<hp:run>` elements. A run is
+//! a slice of the paragraph sharing `charPrIDRef`; it can hold:
+//!
+//! - `<hp:t>` text — the only thing that produces visible characters.
+//! - `<hp:tbl>` tables — inline objects anchored to the paragraph.
+//! - `<hp:fieldBegin type="HYPERLINK">` / `<hp:fieldEnd>` pairs that
+//!   bracket the runs belonging to one hyperlink. Toggle-style: any
+//!   runs between the two markers are "inside" a hyperlink.
+//! - Miscellaneous controls (`<hp:secPr>`, `<hp:ctrl>`, `<hp:colPr>`,
+//!   `<hp:linesegarray>`, `<hp:fwSpace>`, ...). These do not
+//!   contribute text; we skip past their subtrees.
+
+use std::io::BufRead;
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+
+use crate::document::section::types::{Paragraph, Run, Table};
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{attr_string, attr_u32, local_name};
+use super::table::parse_table;
+
+/// Parse an `<hp:p>` element whose start tag has already been
+/// consumed from the reader. Consumes through the matching `</hp:p>`.
+///
+/// `depth` is the current nesting depth. A top-level section
+/// paragraph starts at depth 0; a cell paragraph inherits the enclosing
+/// table's depth + 1 so that nested tables seen inside it get the
+/// correct `nesting_depth` without a second pass.
+pub(super) fn parse_paragraph<B: BufRead>(
+    reader: &mut Reader<B>,
+    start: &BytesStart<'_>,
+    depth: u32,
+) -> DvcResult<Paragraph> {
+    let mut para = Paragraph {
+        para_pr_id_ref: attr_u32(start.attributes(), b"paraPrIDRef")?,
+        style_id_ref: attr_u32(start.attributes(), b"styleIDRef")?,
+        runs: Vec::new(),
+        tables: Vec::new(),
+    };
+
+    // Hyperlink-field bracket state. `FieldBegin type="HYPERLINK"`
+    // flips this on; `FieldEnd` flips it off. At `</run>` close time,
+    // we record the current value on the run: a run that saw the
+    // `FieldBegin` in its body closes with the flag set and is
+    // therefore flagged; a run that saw only the `FieldEnd` closes
+    // with the flag cleared.
+    let mut in_hyperlink = false;
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"run" => {
+                parse_run(reader, e, &mut para, depth, &mut in_hyperlink)?;
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"run" => {
+                // Control-only empty run — no children means no text
+                // and no field-marker state change.
+                para.runs.push(Run {
+                    char_pr_id_ref: attr_u32(e.attributes(), b"charPrIDRef")?,
+                    text: String::new(),
+                    is_hyperlink: in_hyperlink,
+                });
+            }
+            Event::End(ref e) if local_name(e.name()) == b"p" => return Ok(para),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <p>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parse one `<hp:run>` body, pushing the run (and any inline tables
+/// it owns) into `para`. Consumes through the matching `</hp:run>`.
+///
+/// `in_hyperlink` is a rolling flag owned by the parent paragraph:
+/// `FieldBegin`/`FieldEnd` markers encountered inside the run toggle
+/// it, and the value at `</run>` time is what the run records.
+fn parse_run<B: BufRead>(
+    reader: &mut Reader<B>,
+    start: &BytesStart<'_>,
+    para: &mut Paragraph,
+    depth: u32,
+    in_hyperlink: &mut bool,
+) -> DvcResult<()> {
+    let char_pr_id_ref = attr_u32(start.attributes(), b"charPrIDRef")?;
+    let mut text = String::new();
+    let mut tables: Vec<Table> = Vec::new();
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) => match local_name(e.name()) {
+                b"t" => {
+                    let collected = read_t_text(reader)?;
+                    text.push_str(&collected);
+                }
+                b"tbl" => {
+                    let t = parse_table(reader, e, depth)?;
+                    tables.push(t);
+                }
+                b"fieldBegin" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = true;
+                    skip(reader, e)?;
+                }
+                b"fieldEnd" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = false;
+                    skip(reader, e)?;
+                }
+                _ => skip(reader, e)?,
+            },
+            Event::Empty(ref e) => match local_name(e.name()) {
+                b"fieldBegin" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = true;
+                }
+                b"fieldEnd" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = false;
+                }
+                b"t" => {
+                    // Empty text element — nothing to collect.
+                }
+                // Other inline controls (`<hp:tab/>`, `<hp:fwSpace/>`,
+                // `<hp:lineBreak/>`, `<hp:colPr/>`, ...) contribute
+                // nothing to the AST surface we expose.
+                _ => {}
+            },
+            Event::End(ref e) if local_name(e.name()) == b"run" => {
+                para.runs.push(Run {
+                    char_pr_id_ref,
+                    text,
+                    is_hyperlink: *in_hyperlink,
+                });
+                para.tables.extend(tables);
+                return Ok(());
+            }
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <run>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Read the text content of an `<hp:t>` element up to its closing tag.
+///
+/// The element may contain `Event::Text` interleaved with inline
+/// controls (`<hp:tab/>`, `<hp:fwSpace/>`, `<hp:lineBreak/>`, ...).
+/// We preserve only text because only text contributes to validation
+/// (control codes are checked via `<hp:secPr>` and friends, which live
+/// outside `<hp:t>`).
+fn read_t_text<B: BufRead>(reader: &mut Reader<B>) -> DvcResult<String> {
+    let mut out = String::new();
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Text(t) => {
+                let decoded = t
+                    .decode()
+                    .map_err(|e| DvcError::Document(format!("text decode in <t>: {e}")))?;
+                out.push_str(&decoded);
+            }
+            Event::CData(c) => {
+                let s = String::from_utf8(c.into_inner().to_vec())
+                    .map_err(|e| DvcError::Document(format!("cdata utf8 in <t>: {e}")))?;
+                out.push_str(&s);
+            }
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Empty(_) => {}
+            Event::End(ref e) if local_name(e.name()) == b"t" => return Ok(out),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <t>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Skip over a start element's body, consuming through its matching
+/// end tag.
+pub(super) fn skip<B: BufRead>(reader: &mut Reader<B>, start: &BytesStart<'_>) -> DvcResult<()> {
+    reader.read_to_end_into(start.name(), &mut Vec::new())?;
+    Ok(())
+}
+
+/// Return `true` if the `type=` attribute of a `<hp:fieldBegin>` or
+/// `<hp:fieldEnd>` element is `HYPERLINK`.
+fn is_hyperlink_field(e: &BytesStart<'_>) -> DvcResult<bool> {
+    let t = attr_string(e.attributes(), b"type")?;
+    Ok(t.eq_ignore_ascii_case("HYPERLINK"))
+}

--- a/crates/hwp-dvc-core/src/document/section/parser/section.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/section.rs
@@ -1,0 +1,68 @@
+//! Top-level `<hs:sec>` dispatcher.
+//!
+//! The section root contains zero or more `<hp:p>` children. Everything
+//! else at this level (stray whitespace, processing instructions, the
+//! XML declaration) is ignored. Each `<hp:p>` is handed off to the
+//! paragraph walker.
+
+use std::io::BufRead;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::document::section::types::Section;
+use crate::error::DvcResult;
+
+use super::common::local_name;
+use super::paragraph::parse_paragraph;
+
+/// Parse one `Contents/sectionN.xml` byte slice into a [`Section`].
+///
+/// `index` is the numeric `N` extracted from the part filename
+/// (`sectionN.xml`) and preserved on the returned [`Section`] so that
+/// downstream code can re-emit it in error messages.
+pub fn parse_section(index: u32, bytes: &[u8]) -> DvcResult<Section> {
+    let mut reader = Reader::from_reader(bytes);
+    let config = reader.config_mut();
+    // Leave text alone — paragraph text must preserve surrounding
+    // whitespace because the OWPML reference keeps it verbatim.
+    config.trim_text(false);
+    config.expand_empty_elements = false;
+
+    let mut section = Section {
+        index,
+        paragraphs: Vec::new(),
+    };
+
+    dispatch(&mut reader, &mut section)?;
+    Ok(section)
+}
+
+fn dispatch<B: BufRead>(reader: &mut Reader<B>, section: &mut Section) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    // nesting_depth = 0 at the section root — any `<hp:tbl>` produced
+    // directly inside a top-level paragraph becomes a depth-0 table.
+    let base_depth = 0u32;
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"p" => {
+                let para = parse_paragraph(reader, e, base_depth)?;
+                section.paragraphs.push(para);
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"p" => {
+                // Empty paragraph — rare but legal.
+                let para = crate::document::section::types::Paragraph {
+                    para_pr_id_ref: super::common::attr_u32(e.attributes(), b"paraPrIDRef")?,
+                    style_id_ref: super::common::attr_u32(e.attributes(), b"styleIDRef")?,
+                    runs: Vec::new(),
+                    tables: Vec::new(),
+                };
+                section.paragraphs.push(para);
+            }
+            Event::Eof => return Ok(()),
+            _ => {}
+        }
+        buf.clear();
+    }
+}

--- a/crates/hwp-dvc-core/src/document/section/parser/table.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/table.rs
@@ -1,0 +1,158 @@
+//! `<hp:tbl>`, `<hp:tr>`, `<hp:tc>` walker.
+//!
+//! A table carries top-level attributes (`id`, `borderFillIDRef`,
+//! `rowCnt`, `colCnt`) and a sequence of `<hp:tr>` rows. Each row is
+//! a sequence of `<hp:tc>` cells. Each cell has a `<hp:subList>`
+//! containing more paragraphs; those paragraphs can themselves
+//! contain tables, which is exactly how table nesting is expressed.
+//!
+//! This walker increments `nesting_depth` when descending from a cell
+//! into its paragraphs: the parent table's depth + 1 becomes the
+//! depth reported by any `<hp:tbl>` found inside. The top-level
+//! section walker starts at depth 0, so a table directly in a body
+//! paragraph reports depth 0, a table inside its cell reports depth
+//! 1, and so on.
+
+use std::io::BufRead;
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+
+use crate::document::section::types::{Cell, Row, Table};
+use crate::error::{DvcError, DvcResult};
+
+use super::common::{attr_u32, local_name};
+use super::paragraph::{parse_paragraph, skip};
+
+/// Parse an `<hp:tbl>` element whose start tag has already been
+/// consumed from the reader. `parent_depth` is the nesting depth the
+/// enclosing paragraph was walked at. The returned table's
+/// `nesting_depth == parent_depth` (i.e., a table directly in a
+/// body-level paragraph is depth 0).
+pub(super) fn parse_table<B: BufRead>(
+    reader: &mut Reader<B>,
+    start: &BytesStart<'_>,
+    parent_depth: u32,
+) -> DvcResult<Table> {
+    let mut table = Table {
+        id: attr_u32(start.attributes(), b"id")?,
+        border_fill_id_ref: attr_u32(start.attributes(), b"borderFillIDRef")?,
+        row_cnt: attr_u32(start.attributes(), b"rowCnt")?,
+        col_cnt: attr_u32(start.attributes(), b"colCnt")?,
+        rows: Vec::new(),
+        nesting_depth: parent_depth,
+    };
+
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"tr" => {
+                let row = parse_row(reader, parent_depth)?;
+                table.rows.push(row);
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"tr" => {
+                // Row with no cells — degenerate but legal.
+                let _ = e; // attributes unused for an empty row
+                table.rows.push(Row::default());
+            }
+            Event::End(ref e) if local_name(e.name()) == b"tbl" => return Ok(table),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <tbl>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parse an `<hp:tr>` body up to its closing tag.
+fn parse_row<B: BufRead>(reader: &mut Reader<B>, parent_depth: u32) -> DvcResult<Row> {
+    let mut row = Row::default();
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"tc" => {
+                let cell = parse_cell(reader, e, parent_depth)?;
+                row.cells.push(cell);
+            }
+            Event::End(ref e) if local_name(e.name()) == b"tr" => return Ok(row),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <tr>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parse an `<hp:tc>` cell body.
+///
+/// A cell has exactly one `<hp:subList>` (a paragraph container) and
+/// one `<hp:cellAddr>` (row/col coordinates), plus assorted sizing
+/// children we ignore. The subList is walked at `parent_depth + 1`
+/// so tables nested inside get the right depth.
+fn parse_cell<B: BufRead>(
+    reader: &mut Reader<B>,
+    start: &BytesStart<'_>,
+    parent_depth: u32,
+) -> DvcResult<Cell> {
+    let mut cell = Cell {
+        row: 0,
+        col: 0,
+        border_fill_id_ref: attr_u32(start.attributes(), b"borderFillIDRef")?,
+        paragraphs: Vec::new(),
+    };
+
+    let child_depth = parent_depth.saturating_add(1);
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) => match local_name(e.name()) {
+                b"subList" => {
+                    parse_sub_list(reader, &mut cell.paragraphs, child_depth)?;
+                }
+                _ => skip(reader, e)?,
+            },
+            Event::Empty(ref e) if local_name(e.name()) == b"cellAddr" => {
+                cell.col = attr_u32(e.attributes(), b"colAddr")?;
+                cell.row = attr_u32(e.attributes(), b"rowAddr")?;
+            }
+            Event::End(ref e) if local_name(e.name()) == b"tc" => return Ok(cell),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <tc>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parse an `<hp:subList>` — a flat paragraph container inside a cell.
+fn parse_sub_list<B: BufRead>(
+    reader: &mut Reader<B>,
+    out: &mut Vec<crate::document::section::types::Paragraph>,
+    depth: u32,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) if local_name(e.name()) == b"p" => {
+                let para = parse_paragraph(reader, e, depth)?;
+                out.push(para);
+            }
+            Event::Empty(ref e) if local_name(e.name()) == b"p" => {
+                out.push(crate::document::section::types::Paragraph {
+                    para_pr_id_ref: attr_u32(e.attributes(), b"paraPrIDRef")?,
+                    style_id_ref: attr_u32(e.attributes(), b"styleIDRef")?,
+                    runs: Vec::new(),
+                    tables: Vec::new(),
+                });
+            }
+            Event::End(ref e) if local_name(e.name()) == b"subList" => return Ok(()),
+            Event::Start(ref e) => skip(reader, e)?,
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <subList>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}

--- a/crates/hwp-dvc-core/src/document/section/types/mod.rs
+++ b/crates/hwp-dvc-core/src/document/section/types/mod.rs
@@ -1,0 +1,21 @@
+//! Typed AST for OWPML `Contents/section*.xml`.
+//!
+//! The shape set here mirrors the relevant parts of the reference C++
+//! (`OWPMLReader.cpp`, `RTable.{h,cpp}`) while staying simpler: we only
+//! keep the fields a downstream validator or the Phase 1c
+//! `RunTypeInfo` builder (#4) needs. Heavy layout data
+//! (`linesegarray`, `secPr`, page geometry) is intentionally dropped —
+//! those belong to the deferred paging work (#19).
+//!
+//! # Module layout
+//!
+//! - [`nodes`] — the paragraph/run/table struct records and their impls.
+//!
+//! Every element carries the IDs the `HeaderTables` are keyed on
+//! (`paraPrIDRef`, `charPrIDRef`, `styleIDRef`, `borderFillIDRef`) as
+//! plain `u32`s. Resolving those IDs into shape records is out of
+//! scope for this issue (#3) and done by the validators.
+
+pub mod nodes;
+
+pub use nodes::{Cell, Paragraph, Row, Run, Section, Table};

--- a/crates/hwp-dvc-core/src/document/section/types/nodes.rs
+++ b/crates/hwp-dvc-core/src/document/section/types/nodes.rs
@@ -1,0 +1,264 @@
+//! AST node definitions for an OWPML body section.
+//!
+//! The five kinds of nodes mirror the OWPML element hierarchy closely
+//! enough that a walker can visit them without further indirection:
+//!
+//! ```text
+//! Section
+//! └── Paragraph (hp:p)
+//!     ├── Run (hp:run)
+//!     │   └── text / hyperlink marker
+//!     └── Table (hp:tbl)                 // tables attached to this paragraph
+//!         └── Row (hp:tr)
+//!             └── Cell (hp:tc)
+//!                 └── Paragraph (hp:subList/hp:p)   // recurses
+//!                     └── Table (hp:tbl, nested)    // nesting_depth += 1
+//! ```
+//!
+//! Nesting depth is recorded on every `Table` so that issue #4 can
+//! set `RunTypeInfo::is_in_table_in_table` correctly without walking
+//! the tree a second time: any table with `nesting_depth >= 1` is a
+//! table-in-table.
+//!
+//! `Cell` paragraphs may recursively contain more tables; that case
+//! drives the nesting-depth counter. See `parser::section` for the
+//! walker that builds this AST.
+
+/// A parsed OWPML body section — the output of parsing one
+/// `Contents/section*.xml` part.
+///
+/// A well-formed section has at least one paragraph (HWPX writers
+/// always emit at least the section-definition paragraph carrying
+/// `<hp:secPr>`). The walker preserves document order: the `i`-th
+/// element of `paragraphs` corresponds to the `i`-th `<hp:p>` child of
+/// the `<hs:sec>` root.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Section {
+    /// The ordinal of the source file this section was parsed from,
+    /// extracted from the `Contents/sectionN.xml` filename. Preserved
+    /// so that downstream code can re-emit the original file path in
+    /// error messages.
+    pub index: u32,
+    /// Paragraphs in document order.
+    pub paragraphs: Vec<Paragraph>,
+}
+
+/// A single `<hp:p>` paragraph.
+///
+/// All OWPML paragraph elements carry `paraPrIDRef` and `styleIDRef`
+/// attributes even when they reference id 0. We copy both here as
+/// plain integers — resolution into [`ParaShape`] / [`Style`] records
+/// is the validator's responsibility.
+///
+/// Tables attached to the paragraph are kept in a dedicated vector
+/// rather than flattened into the run stream so that the walker can
+/// reason about "paragraph has N tables" without re-scanning the
+/// runs. In OWPML, tables live *inside* `<hp:run>` elements (a table
+/// is a kind of inline object), but for the validator surface the
+/// "which paragraph does this table belong to" relationship is what
+/// matters.
+///
+/// [`ParaShape`]: crate::document::header::ParaShape
+/// [`Style`]: crate::document::header::Style
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Paragraph {
+    /// `paraPrIDRef` — index into [`HeaderTables::para_shapes`].
+    ///
+    /// [`HeaderTables::para_shapes`]: crate::document::header::HeaderTables
+    pub para_pr_id_ref: u32,
+    /// `styleIDRef` — index into [`HeaderTables::styles`].
+    /// Zero means "no explicit style override"; validators interpret
+    /// that as "use the default 바탕글 style".
+    ///
+    /// [`HeaderTables::styles`]: crate::document::header::HeaderTables
+    pub style_id_ref: u32,
+    /// Text-bearing runs in document order.
+    pub runs: Vec<Run>,
+    /// Tables owned by this paragraph, in document order.
+    pub tables: Vec<Table>,
+}
+
+/// A single `<hp:run>` — a character-property-homogeneous slice of
+/// a paragraph.
+///
+/// Only the fields the Phase 2 validators need are preserved:
+///
+/// - `char_pr_id_ref` drives `CheckCharShape` / `CheckSpecialCharacter`
+/// - `text` is the concatenated body of `<hp:t>` children
+/// - `is_hyperlink` is set when the run sits between a
+///   `<hp:fieldBegin type="HYPERLINK">` / `<hp:fieldEnd>` pair.
+///
+/// Runs with no text (pure control runs carrying `<hp:secPr>` or
+/// `<hp:ctrl>`) still show up — callers can filter them out when
+/// reporting on run text.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Run {
+    /// `charPrIDRef` — index into [`HeaderTables::char_shapes`].
+    ///
+    /// [`HeaderTables::char_shapes`]: crate::document::header::HeaderTables
+    pub char_pr_id_ref: u32,
+    /// Concatenated text content of every `<hp:t>` child of the run.
+    /// Empty for control-only runs.
+    pub text: String,
+    /// `true` if this run is enclosed by a
+    /// `<hp:fieldBegin type="HYPERLINK">` / `<hp:fieldEnd>` pair
+    /// anywhere earlier in the paragraph.
+    pub is_hyperlink: bool,
+}
+
+/// A single `<hp:tbl>` table.
+///
+/// `nesting_depth` is the count of enclosing `<hp:tbl>` ancestors;
+/// top-level tables have depth 0 and a table directly inside another
+/// table's cell has depth 1. Anything `>= 1` is a "table in table"
+/// for issue #4's purposes.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Table {
+    /// The `id` attribute of the `<hp:tbl>` element. Non-unique across
+    /// nested tables but unique within a single section for a given
+    /// nesting path, which is all the validators require.
+    pub id: u32,
+    /// `borderFillIDRef` — index into [`HeaderTables::border_fills`]
+    /// for the table's outer border style.
+    ///
+    /// [`HeaderTables::border_fills`]: crate::document::header::HeaderTables
+    pub border_fill_id_ref: u32,
+    /// `rowCnt` attribute. Redundant with `rows.len()` but kept
+    /// because the OWPML writer sometimes emits partial row trees
+    /// (missing `<hp:tr>` tags) and the declared count is what a
+    /// downstream validator should report.
+    pub row_cnt: u32,
+    /// `colCnt` attribute.
+    pub col_cnt: u32,
+    /// Rows in document order.
+    pub rows: Vec<Row>,
+    /// 0 for a top-level table, 1 inside a cell of a top-level table,
+    /// 2 inside a cell of a nested table, and so on.
+    pub nesting_depth: u32,
+}
+
+/// A single `<hp:tr>` row inside a [`Table`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Row {
+    pub cells: Vec<Cell>,
+}
+
+/// A single `<hp:tc>` cell inside a [`Row`].
+///
+/// `row`/`col` mirror the `<hp:cellAddr>` 0-indexed coordinates. The
+/// paragraph vector is recursive — cell paragraphs are full
+/// [`Paragraph`] values and can themselves own [`Table`]s, which is
+/// exactly how the walker discovers nested tables.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Cell {
+    /// 0-indexed row address from `<hp:cellAddr rowAddr="..">`.
+    pub row: u32,
+    /// 0-indexed column address from `<hp:cellAddr colAddr="..">`.
+    pub col: u32,
+    /// `borderFillIDRef` for this cell's border style.
+    pub border_fill_id_ref: u32,
+    /// Paragraphs inside the cell's `<hp:subList>`, in document order.
+    pub paragraphs: Vec<Paragraph>,
+}
+
+impl Section {
+    /// Iterate over every table that appears anywhere in the section,
+    /// yielding borrowed `Table` references in document order.
+    ///
+    /// The iterator visits tables at every nesting level, so a caller
+    /// interested only in top-level tables can filter with
+    /// `.filter(|t| t.nesting_depth == 0)`.
+    pub fn all_tables(&self) -> impl Iterator<Item = &Table> + '_ {
+        TableIter::new(self)
+    }
+
+    /// Iterate over every paragraph anywhere in the section,
+    /// descending into table cells. Order is document order.
+    pub fn all_paragraphs(&self) -> impl Iterator<Item = &Paragraph> + '_ {
+        ParagraphIter::new(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Iterators
+// ---------------------------------------------------------------------------
+
+/// Depth-first iterator over every [`Table`] in a [`Section`].
+///
+/// Visits tables attached to a paragraph before descending into the
+/// paragraphs nested inside each of that table's cells. This matches
+/// the order in which [`Cell::paragraphs`] lays them out.
+struct TableIter<'a> {
+    // Stack of paragraphs still to descend into.
+    para_stack: Vec<&'a Paragraph>,
+    // Tables remaining to yield from the most recently popped paragraph.
+    current_tables: std::slice::Iter<'a, Table>,
+}
+
+impl<'a> TableIter<'a> {
+    fn new(section: &'a Section) -> Self {
+        Self {
+            para_stack: section.paragraphs.iter().rev().collect(),
+            current_tables: [].iter(),
+        }
+    }
+}
+
+impl<'a> Iterator for TableIter<'a> {
+    type Item = &'a Table;
+
+    fn next(&mut self) -> Option<&'a Table> {
+        loop {
+            if let Some(t) = self.current_tables.next() {
+                // Queue cell paragraphs so nested tables are yielded
+                // after this one. Push in reverse so the stack pops in
+                // document order.
+                for row in t.rows.iter().rev() {
+                    for cell in row.cells.iter().rev() {
+                        for p in cell.paragraphs.iter().rev() {
+                            self.para_stack.push(p);
+                        }
+                    }
+                }
+                return Some(t);
+            }
+            let p = self.para_stack.pop()?;
+            self.current_tables = p.tables.iter();
+        }
+    }
+}
+
+/// Depth-first iterator over every [`Paragraph`] in a [`Section`],
+/// descending into table cells.
+struct ParagraphIter<'a> {
+    stack: Vec<&'a Paragraph>,
+}
+
+impl<'a> ParagraphIter<'a> {
+    fn new(section: &'a Section) -> Self {
+        let mut stack: Vec<&'a Paragraph> = section.paragraphs.iter().rev().collect();
+        // If no top-level paragraphs exist, the stack starts empty;
+        // `next()` will return `None` immediately.
+        stack.shrink_to_fit();
+        Self { stack }
+    }
+}
+
+impl<'a> Iterator for ParagraphIter<'a> {
+    type Item = &'a Paragraph;
+
+    fn next(&mut self) -> Option<&'a Paragraph> {
+        let p = self.stack.pop()?;
+        // Push cell paragraphs in reverse so they pop in document order.
+        for t in p.tables.iter().rev() {
+            for row in t.rows.iter().rev() {
+                for cell in row.cells.iter().rev() {
+                    for cp in cell.paragraphs.iter().rev() {
+                        self.stack.push(cp);
+                    }
+                }
+            }
+        }
+        Some(p)
+    }
+}

--- a/crates/hwp-dvc-core/tests/section_parsing.rs
+++ b/crates/hwp-dvc-core/tests/section_parsing.rs
@@ -1,0 +1,149 @@
+//! Integration tests for `HwpxArchive::read_sections()` against real
+//! HWPX fixtures committed under `tests/fixtures/docs/`.
+//!
+//! Each test opens a fixture end-to-end, parses its
+//! `Contents/section*.xml` parts, and asserts a concrete structural
+//! fact about the paragraph AST — never just "it didn't panic".
+//!
+//! | Fixture              | Assertion                                          |
+//! |----------------------|----------------------------------------------------|
+//! | `parashape_pass`     | plain-paragraph baseline: non-empty Korean run.    |
+//! | `table_nested`       | outer 2x2 table is depth 0 with 4 cells.           |
+//! | `table_nested`       | inner table exists somewhere at nesting depth 1.   |
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::document::section::{Section, Table};
+use hwp_dvc_core::document::HwpxArchive;
+
+/// Absolute path to a fixture under `tests/fixtures/docs/`.
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("docs");
+    p.push(name);
+    p
+}
+
+fn load_sections(name: &str) -> Vec<Section> {
+    let archive = HwpxArchive::open(fixture(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    archive
+        .read_sections()
+        .unwrap_or_else(|e| panic!("failed to parse sections in {name}: {e}"))
+}
+
+/// Return `true` if `s` contains at least one character in the
+/// Korean syllable range (U+AC00..=U+D7A3). Used instead of hard-coded
+/// phrase checks because the fixture's sample body may evolve while
+/// remaining Korean-language content.
+fn contains_korean(s: &str) -> bool {
+    s.chars().any(|c| ('\u{AC00}'..='\u{D7A3}').contains(&c))
+}
+
+#[test]
+fn parashape_pass_section_has_paragraphs() {
+    let sections = load_sections("parashape_pass.hwpx");
+
+    assert!(
+        !sections.is_empty(),
+        "parashape_pass must expose at least one section part"
+    );
+
+    for sec in &sections {
+        assert!(
+            !sec.paragraphs.is_empty(),
+            "section {} in parashape_pass must contain at least one paragraph",
+            sec.index
+        );
+    }
+
+    // The fixture body is a Korean-language paragraph; at least one
+    // run somewhere in the document must carry non-empty Korean text.
+    let has_korean_text = sections.iter().any(|s| {
+        s.all_paragraphs().any(|p| {
+            p.runs
+                .iter()
+                .any(|r| !r.text.is_empty() && contains_korean(&r.text))
+        })
+    });
+
+    assert!(
+        has_korean_text,
+        "expected at least one run with non-empty Korean text in parashape_pass; \
+         got run texts: {:?}",
+        sections
+            .iter()
+            .flat_map(|s| s
+                .all_paragraphs()
+                .flat_map(|p| p.runs.iter().map(|r| r.text.clone())))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn table_nested_section_detects_outer_table() {
+    let sections = load_sections("table_nested.hwpx");
+
+    let top_level_tables: Vec<&Table> = sections
+        .iter()
+        .flat_map(|s| s.all_tables().filter(|t| t.nesting_depth == 0))
+        .collect();
+
+    assert!(
+        !top_level_tables.is_empty(),
+        "table_nested must contain at least one top-level (depth=0) table"
+    );
+
+    // The fixture is authored as a 2x2 outer table. The declared
+    // `rowCnt`/`colCnt` on the outer table must agree with that
+    // shape, and the actual row/cell tree must yield at least 4
+    // cells across its rows.
+    let outer = top_level_tables[0];
+    assert!(
+        outer.row_cnt >= 2 && outer.col_cnt >= 2,
+        "outer table must declare at least a 2x2 grid; got rowCnt={} colCnt={}",
+        outer.row_cnt,
+        outer.col_cnt
+    );
+
+    let total_cells: usize = outer.rows.iter().map(|r| r.cells.len()).sum();
+    assert!(
+        total_cells >= 4,
+        "outer table must expose at least 4 cells across its rows; got {total_cells}"
+    );
+}
+
+#[test]
+fn table_nested_section_detects_inner_table() {
+    let sections = load_sections("table_nested.hwpx");
+
+    let inner_tables: Vec<&Table> = sections
+        .iter()
+        .flat_map(|s| s.all_tables().filter(|t| t.nesting_depth >= 1))
+        .collect();
+
+    assert!(
+        !inner_tables.is_empty(),
+        "table_nested must expose at least one nested (depth>=1) table inside a cell; \
+         all tables discovered: {:?}",
+        sections
+            .iter()
+            .flat_map(|s| s.all_tables().map(|t| (t.id, t.nesting_depth)))
+            .collect::<Vec<_>>()
+    );
+
+    // The nesting pattern for the fixture is a single 1x1 inner table
+    // inside cell (1,1) of the outer 2x2. nesting_depth exactly 1 is
+    // what Phase 1c (#4) reads; assert it to guard against accidental
+    // off-by-one depth changes in the walker.
+    assert!(
+        inner_tables.iter().any(|t| t.nesting_depth == 1),
+        "expected a nested table at nesting_depth == 1; got depths: {:?}",
+        inner_tables
+            .iter()
+            .map(|t| t.nesting_depth)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary
- Implements the OWPML `Contents/section*.xml` paragraph/run/table parser under `document::section`, exposing `HwpxArchive::read_sections() -> DvcResult<Vec<Section>>`.
- Walker is recursive: cell paragraphs can contain more tables, and each `Table` records its `nesting_depth` so issue #4 can set `is_in_table_in_table` without a second pass.
- Hyperlink field markers (`<hp:fieldBegin type="HYPERLINK">` / `<hp:fieldEnd>`) toggle a rolling paragraph flag; runs record the flag state at `</hp:run>`-close time as `Run::is_hyperlink`.
- Section module is split across seven small files (`types/`, `parser/{mod,common,section,paragraph,table}.rs`) — no file exceeds 265 lines, matching the 500-line soft cap set by the header parser.

## Acceptance criteria
- [x] `document::section::Section` AST with `paragraphs: Vec<Paragraph>` containing runs, tables, and control markers.
- [x] Recursive walker handles nested tables; depth is exposed so the next issue can set `is_in_table_in_table`.
- [x] Unit tests against a hand-crafted section fixture with text, a table, and a nested table.
- [x] Depends on #2 for shape ID references.

## Integration test fixtures
Tests live at `crates/hwp-dvc-core/tests/section_parsing.rs` and load:

- `parashape_pass.hwpx` — baseline plain-paragraph fixture. Asserts sections are present, every section has at least one paragraph, and at least one run carries non-empty Korean text.
- `table_nested.hwpx` — 2x2 outer table containing a 1x1 inner table in cell (1,1). Two tests: one asserts the outer table is at `nesting_depth == 0` with at least 4 cells across rows, the other asserts a nested table exists at `nesting_depth == 1`.

## Test plan
- [x] `cargo test --workspace` — 16 tests pass (4 header integration + 3 section integration + 3 spec + 6 section unit).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `rustfmt` run on the new files only; unrelated pre-existing format drift is untouched.