### PR TITLE
feat: build RunTypeInfo with context metadata (closes #4)

### DIFF
--- a/crates/hwp-dvc-core/src/document/mod.rs
+++ b/crates/hwp-dvc-core/src/document/mod.rs
@@ -18,8 +18,10 @@
 //! Submodules:
 //! - [`header`] — `Contents/header.xml` shape tables (issue #2).
 //! - [`section`] — `Contents/section*.xml` paragraph AST (issue #3).
+//! - [`run_type`] — `Vec<RunTypeInfo>` builder (issue #4).
 
 pub mod header;
+pub mod run_type;
 pub mod section;
 
 use std::io::Read;
@@ -129,21 +131,57 @@ fn section_index(name: &str) -> Option<u32> {
     num.parse::<u32>().ok()
 }
 
-/// Placeholder result of parsing the OWPML document — to be fleshed
-/// out as validators start needing concrete shape data.
+/// The result of parsing an HWPX document end-to-end.
+///
+/// After [`Document::open`] the struct only holds the raw
+/// [`HwpxArchive`]; calling [`Document::parse`] fills in
+/// [`Self::header`], [`Self::sections`], and [`Self::run_type_infos`]
+/// in one pass. Validators never interact with the archive directly —
+/// they read from the three populated fields.
+///
+/// All three populated fields are `Option`-less because a successful
+/// parse guarantees each has a value; the initial "unparsed" state is
+/// reflected by an empty `sections` vector and `header == None`
+/// rather than any sentinel. `header` stays `Option<HeaderTables>` so
+/// that callers that deliberately skip parsing (e.g., listing parts
+/// for debugging) can distinguish "we haven't parsed yet" from "the
+/// parse produced an empty table" — both are legal states.
 #[derive(Debug, Default)]
 pub struct Document {
     pub archive: HwpxArchive,
+    /// Parsed header tables (`Contents/header.xml`), or `None` before
+    /// [`Document::parse`] is called. Validators can assume this is
+    /// `Some` once `parse` has returned `Ok`.
+    pub header: Option<HeaderTables>,
+    /// Parsed body sections (`Contents/section*.xml`), in ascending
+    /// `N` order. Empty before [`Document::parse`] is called.
+    pub sections: Vec<Section>,
+    /// The flattened `RunTypeInfo` stream, in document order, across
+    /// all sections. This is the unit of validation every Phase 2
+    /// validator consumes.
     pub run_type_infos: Vec<RunTypeInfo>,
 }
 
 /// Mirrors `RunTypeInfo` in `references/dvc/Source/OWPMLReader.h`.
+///
+/// # Out-of-scope fields
+///
+/// `page_no` / `line_no` stay `0` in this issue. Layout-engine-based
+/// page and line numbering is tracked separately as issue
+/// [#19](https://github.com/inureyes/hwp-dvc/issues/19) because it
+/// requires porting the reference's vertical-position walk through
+/// `<hp:linesegarray>` — work that is deferred behind Phases 2/3
+/// since no validator currently consumes pagination.
 #[derive(Debug, Default, Clone)]
 pub struct RunTypeInfo {
     pub char_pr_id_ref: u32,
     pub para_pr_id_ref: u32,
     pub text: String,
+    /// Always `0` in this crate version — see [`RunTypeInfo`] doc and
+    /// [`crate::document::run_type::PAGE_LINE_OUT_OF_SCOPE`].
     pub page_no: u32,
+    /// Always `0` in this crate version — see [`RunTypeInfo`] doc and
+    /// [`crate::document::run_type::PAGE_LINE_OUT_OF_SCOPE`].
     pub line_no: u32,
     pub is_in_table: bool,
     pub is_in_table_in_table: bool,
@@ -161,13 +199,28 @@ impl Document {
         let archive = HwpxArchive::open(path)?;
         Ok(Self {
             archive,
+            header: None,
+            sections: Vec::new(),
             run_type_infos: Vec::new(),
         })
     }
 
-    /// Parse the OWPML body into `RunTypeInfo` entries.
-    /// TODO: port from `OWPMLReader::GetRunTypeInfos`.
+    /// Parse the OWPML header + body into [`Self::header`],
+    /// [`Self::sections`] and [`Self::run_type_infos`].
+    ///
+    /// Idempotent: calling it a second time re-parses from the
+    /// archive bytes and replaces the previous state. `DvcError` is
+    /// returned if any sub-parse (header, section) fails; the
+    /// document state is left unchanged in that case.
     pub fn parse(&mut self) -> DvcResult<()> {
-        Err(DvcError::NotImplemented("Document::parse (OWPML reader)"))
+        let header = self.archive.read_header()?;
+        let sections = self.archive.read_sections()?;
+        let run_type_infos = run_type::build_run_type_infos(&header, &sections);
+
+        // Commit only after all sub-parses succeed.
+        self.header = Some(header);
+        self.sections = sections;
+        self.run_type_infos = run_type_infos;
+        Ok(())
     }
 }

--- a/crates/hwp-dvc-core/src/document/run_type/builder.rs
+++ b/crates/hwp-dvc-core/src/document/run_type/builder.rs
@@ -1,0 +1,425 @@
+//! [`build_run_type_infos`] — walk a parsed `HeaderTables` + section
+//! AST and produce the `Vec<RunTypeInfo>` that Phase 2 validators
+//! consume.
+//!
+//! The walk is a straight recursion through paragraphs and tables:
+//! see `PARA_WALK` below. No layout information is produced — that is
+//! the deferred issue #19.
+//!
+//! # Flag semantics
+//!
+//! Every emitted [`RunTypeInfo`] carries the booleans that the
+//! Phase 2 validators gate on:
+//!
+//! | Flag                    | When set                                                          |
+//! |-------------------------|-------------------------------------------------------------------|
+//! | `is_in_table`           | run lives inside any table cell, at any nesting depth             |
+//! | `is_in_table_in_table`  | the innermost enclosing table has `nesting_depth >= 1`            |
+//! | `is_in_shape`           | run lives inside a `<hp:drawText>` — currently always `false`     |
+//! | `is_hyperlink`          | the run sits between a `<hp:fieldBegin type="HYPERLINK">` pair    |
+//! | `is_style`              | paragraph's `styleIDRef` does not resolve to the default 바탕글   |
+//!
+//! `is_in_shape` is intentionally wired as always-false: the section
+//! AST from issue #3 does not yet surface `<hp:drawText>`
+//! containers, and the Phase 2 validators that care about shapes
+//! (notably `CheckCharShape` when it wants to skip runs inside
+//! drawing objects) will add that plumbing in their own PRs. See
+//! [`IS_IN_SHAPE_SIMPLIFICATION`].
+
+use crate::document::header::HeaderTables;
+use crate::document::section::{Cell, Paragraph, Section, Table};
+use crate::document::RunTypeInfo;
+
+/// Human-readable summary of which `<hp:run>` instances map to a
+/// [`RunTypeInfo`]. Kept as a `const` so the rule is discoverable at
+/// the module level and doc-searchable.
+pub const RUN_TYPE_EMISSION_POLICY: &str =
+    "one RunTypeInfo per <hp:run>…</hp:run> (non-empty element), matching the reference's \
+     `if (pRunType && pRunType->HasChildList())` gate. Control-only empty runs emitted by the \
+     section parser are still included because they carry charPrIDRef — excluding them would \
+     drop the charshape signal the Phase 2 validator needs.";
+
+/// Documentation marker: `is_in_shape` stays `false` in this issue.
+/// Drawing-object containers are not yet surfaced by the Section AST
+/// (issue #3); the Phase 2 validator that needs this discrimination
+/// will extend the AST when it lands.
+pub const IS_IN_SHAPE_SIMPLIFICATION: &str =
+    "is_in_shape deferred: <hp:drawText> ancestors not carried through the section AST yet";
+
+/// Consume a [`HeaderTables`] + `Vec<Section>` and produce the
+/// flattened `Vec<RunTypeInfo>` in document order.
+///
+/// Walks every paragraph in every section — including paragraphs
+/// nested inside table cells, recursively — and emits one
+/// [`RunTypeInfo`] per run. `page_no` and `line_no` are left at 0
+/// (see issue #19).
+#[must_use]
+pub fn build_run_type_infos(header: &HeaderTables, sections: &[Section]) -> Vec<RunTypeInfo> {
+    // Resolve the default-style id lazily: many HWPX documents key
+    // 바탕글 to id 0, but Hancom writers occasionally renumber it
+    // and the issue specifically calls out to check the header's
+    // Style table rather than hard-coding 0.
+    let default_style = default_style_id(header);
+
+    // Pre-size loosely: most fixtures emit under 200 runs; oversizing
+    // is cheap because the struct is small.
+    let mut out: Vec<RunTypeInfo> = Vec::with_capacity(sections.len() * 64);
+
+    for section in sections {
+        let ctx = SectionCtx {
+            outline_shape_id_ref: section.outline_shape_id_ref,
+            default_style_id: default_style,
+        };
+        for paragraph in &section.paragraphs {
+            walk_paragraph(&ctx, paragraph, /* cell = */ None, &mut out);
+        }
+    }
+
+    out
+}
+
+/// Resolve the built-in default-style id: the [`Style`] whose `name`
+/// attribute matches `"바탕글"`. Returns 0 if the header has no such
+/// entry (which never happens in a real HWPX but keeps the function
+/// total).
+///
+/// Exposed as `pub` so integration tests can assert the resolution
+/// mirrors what validators will see.
+///
+/// [`Style`]: crate::document::header::Style
+#[must_use]
+pub fn default_style_id(header: &HeaderTables) -> u32 {
+    header
+        .style_by_name("바탕글")
+        .map(|s| s.id)
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Internal walker
+// ---------------------------------------------------------------------------
+
+/// Section-wide context used by the walker. One per section —
+/// intentionally cheap to copy because the walker passes it by
+/// reference.
+struct SectionCtx {
+    /// The `outlineShapeIDRef` resolved from `<hp:secPr>` at section
+    /// parse time. Mirrors the C++ reference's per-section resolution;
+    /// see `RunTypeInfo::outline_shape_id_ref`.
+    outline_shape_id_ref: u32,
+    /// The style id corresponding to 바탕글. A paragraph whose
+    /// `style_id_ref` equals this value is considered "unstyled".
+    default_style_id: u32,
+}
+
+/// Table-cell context accumulated as the walker descends into nested
+/// tables. Top-level paragraphs pass `None`.
+#[derive(Clone, Copy)]
+struct CellCtx {
+    /// The id of the **innermost** enclosing `<hp:tbl>`. Mirrors the
+    /// C++ reference's `pTableType = (CTableType*)pTc->GetParentObj()
+    /// ->GetParentObj()` — i.e., the table that directly owns the
+    /// enclosing cell, not the outermost.
+    table_id: u32,
+    /// The innermost cell's row address.
+    row: u32,
+    /// The innermost cell's column address.
+    col: u32,
+    /// True when the innermost enclosing table has
+    /// `nesting_depth >= 1`. The section walker (#3) already
+    /// encodes nesting depth on each [`Table`]; carrying it here
+    /// lets the run builder avoid a second ancestry scan.
+    is_table_in_table: bool,
+}
+
+/// Walk one [`Paragraph`], emitting one [`RunTypeInfo`] per run and
+/// recursing into any tables owned by the paragraph.
+fn walk_paragraph(
+    ctx: &SectionCtx,
+    p: &Paragraph,
+    cell: Option<CellCtx>,
+    out: &mut Vec<RunTypeInfo>,
+) {
+    let is_style = p.style_id_ref != ctx.default_style_id;
+    for run in &p.runs {
+        let mut info = RunTypeInfo {
+            char_pr_id_ref: run.char_pr_id_ref,
+            para_pr_id_ref: p.para_pr_id_ref,
+            text: run.text.clone(),
+            // Intentionally left 0 — see module-level
+            // `PAGE_LINE_OUT_OF_SCOPE` and issue #19.
+            page_no: 0,
+            line_no: 0,
+            outline_shape_id_ref: ctx.outline_shape_id_ref,
+            is_hyperlink: run.is_hyperlink,
+            is_style,
+            // `is_in_shape` stays false for issue #4 (see module doc).
+            is_in_shape: false,
+            ..RunTypeInfo::default()
+        };
+        if let Some(c) = cell {
+            info.is_in_table = true;
+            info.is_in_table_in_table = c.is_table_in_table;
+            info.table_id = c.table_id;
+            info.table_row = c.row;
+            info.table_col = c.col;
+        }
+        out.push(info);
+    }
+
+    for table in &p.tables {
+        walk_table(ctx, table, out);
+    }
+}
+
+/// Walk one [`Table`], recursing into each cell's paragraphs. The
+/// table's own `nesting_depth` is used to seed `is_table_in_table`
+/// for the runs discovered inside its cells.
+fn walk_table(ctx: &SectionCtx, t: &Table, out: &mut Vec<RunTypeInfo>) {
+    // The reference reports the cell's enclosing table id — not the
+    // outermost table. The walker naturally satisfies that because
+    // it visits the cell via its direct parent table, so `t.id` here
+    // is the right value to stamp.
+    let is_table_in_table = t.nesting_depth >= 1;
+    for row in &t.rows {
+        for cell in &row.cells {
+            walk_cell(ctx, t.id, cell, is_table_in_table, out);
+        }
+    }
+}
+
+fn walk_cell(
+    ctx: &SectionCtx,
+    table_id: u32,
+    cell: &Cell,
+    is_table_in_table: bool,
+    out: &mut Vec<RunTypeInfo>,
+) {
+    let cell_ctx = CellCtx {
+        table_id,
+        row: cell.row,
+        col: cell.col,
+        is_table_in_table,
+    };
+    for p in &cell.paragraphs {
+        walk_paragraph(ctx, p, Some(cell_ctx), out);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (header-free, synthetic AST)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::header::Style;
+    use crate::document::section::{Cell, Paragraph, Row, Run, Section, Table};
+
+    fn header_with_default_style(id: u32) -> HeaderTables {
+        let mut h = HeaderTables::default();
+        h.styles.insert(
+            id,
+            Style {
+                id,
+                style_type: "PARA".into(),
+                name: "바탕글".into(),
+                ..Default::default()
+            },
+        );
+        h
+    }
+
+    fn plain_paragraph(style_id_ref: u32, para_pr_id_ref: u32, text: &str) -> Paragraph {
+        Paragraph {
+            para_pr_id_ref,
+            style_id_ref,
+            runs: vec![Run {
+                char_pr_id_ref: 0,
+                text: text.into(),
+                is_hyperlink: false,
+            }],
+            tables: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn emits_one_info_per_run_top_level() {
+        let h = header_with_default_style(0);
+        let mut s = Section::default();
+        s.paragraphs.push(Paragraph {
+            para_pr_id_ref: 0,
+            style_id_ref: 0,
+            runs: vec![
+                Run {
+                    char_pr_id_ref: 1,
+                    text: "hello".into(),
+                    is_hyperlink: false,
+                },
+                Run {
+                    char_pr_id_ref: 2,
+                    text: " world".into(),
+                    is_hyperlink: false,
+                },
+            ],
+            tables: Vec::new(),
+        });
+
+        let infos = build_run_type_infos(&h, &[s]);
+        assert_eq!(infos.len(), 2);
+        assert_eq!(infos[0].text, "hello");
+        assert_eq!(infos[0].char_pr_id_ref, 1);
+        assert_eq!(infos[1].text, " world");
+        assert_eq!(infos[1].char_pr_id_ref, 2);
+        // Plain top-level runs: table flags off, page/line zero.
+        for i in &infos {
+            assert!(!i.is_in_table);
+            assert!(!i.is_in_table_in_table);
+            assert_eq!(i.page_no, 0);
+            assert_eq!(i.line_no, 0);
+        }
+    }
+
+    #[test]
+    fn flags_hyperlink_runs() {
+        let h = header_with_default_style(0);
+        let mut s = Section::default();
+        s.paragraphs.push(Paragraph {
+            para_pr_id_ref: 0,
+            style_id_ref: 0,
+            runs: vec![
+                Run {
+                    char_pr_id_ref: 0,
+                    text: "plain".into(),
+                    is_hyperlink: false,
+                },
+                Run {
+                    char_pr_id_ref: 0,
+                    text: "linked".into(),
+                    is_hyperlink: true,
+                },
+            ],
+            tables: Vec::new(),
+        });
+        let infos = build_run_type_infos(&h, &[s]);
+        assert!(!infos[0].is_hyperlink);
+        assert!(infos[1].is_hyperlink);
+    }
+
+    #[test]
+    fn flags_styled_paragraph_against_default_style() {
+        // 바탕글 has id=7 in this synthetic header — a paragraph with
+        // style_id_ref=0 is therefore *not* the default (is_style=true),
+        // and style_id_ref=7 is the default (is_style=false).
+        let h = header_with_default_style(7);
+        let mut s = Section::default();
+        s.paragraphs.push(plain_paragraph(0, 0, "not default"));
+        s.paragraphs.push(plain_paragraph(7, 0, "default style"));
+
+        let infos = build_run_type_infos(&h, &[s]);
+        assert!(infos[0].is_style, "id=0 is not 바탕글(id=7) here");
+        assert!(!infos[1].is_style, "id=7 is 바탕글 in this fixture");
+    }
+
+    #[test]
+    fn flags_table_and_table_in_table() {
+        let h = header_with_default_style(0);
+        let mut s = Section::default();
+
+        // Build a 1x1 table whose cell contains a 1x1 nested table
+        // whose cell contains a paragraph. The outermost paragraph
+        // carries no text but owns the outer table.
+        let inner_para = Paragraph {
+            para_pr_id_ref: 0,
+            style_id_ref: 0,
+            runs: vec![Run {
+                char_pr_id_ref: 0,
+                text: "deep".into(),
+                is_hyperlink: false,
+            }],
+            tables: Vec::new(),
+        };
+        let inner_table = Table {
+            id: 222,
+            border_fill_id_ref: 0,
+            row_cnt: 1,
+            col_cnt: 1,
+            rows: vec![Row {
+                cells: vec![Cell {
+                    row: 0,
+                    col: 0,
+                    border_fill_id_ref: 0,
+                    paragraphs: vec![inner_para],
+                }],
+            }],
+            nesting_depth: 1,
+        };
+        let middle_para = Paragraph {
+            para_pr_id_ref: 0,
+            style_id_ref: 0,
+            runs: vec![Run {
+                char_pr_id_ref: 0,
+                text: "middle".into(),
+                is_hyperlink: false,
+            }],
+            tables: vec![inner_table],
+        };
+        let outer_table = Table {
+            id: 111,
+            border_fill_id_ref: 0,
+            row_cnt: 1,
+            col_cnt: 1,
+            rows: vec![Row {
+                cells: vec![Cell {
+                    row: 0,
+                    col: 0,
+                    border_fill_id_ref: 0,
+                    paragraphs: vec![middle_para],
+                }],
+            }],
+            nesting_depth: 0,
+        };
+        s.paragraphs.push(Paragraph {
+            para_pr_id_ref: 0,
+            style_id_ref: 0,
+            runs: Vec::new(),
+            tables: vec![outer_table],
+        });
+
+        let infos = build_run_type_infos(&h, &[s]);
+        // Two runs in total: one in the outer cell's paragraph
+        // ("middle"), one in the inner cell's paragraph ("deep").
+        assert_eq!(infos.len(), 2);
+
+        let middle = infos.iter().find(|i| i.text == "middle").unwrap();
+        assert!(middle.is_in_table);
+        assert!(!middle.is_in_table_in_table);
+        assert_eq!(middle.table_id, 111);
+
+        let deep = infos.iter().find(|i| i.text == "deep").unwrap();
+        assert!(deep.is_in_table);
+        assert!(deep.is_in_table_in_table, "inner table has depth 1");
+        assert_eq!(deep.table_id, 222, "innermost table id is stamped");
+    }
+
+    #[test]
+    fn copies_outline_shape_id_ref_from_section() {
+        let h = header_with_default_style(0);
+        let s = Section {
+            outline_shape_id_ref: 42,
+            paragraphs: vec![plain_paragraph(0, 0, "hi")],
+            ..Default::default()
+        };
+
+        let infos = build_run_type_infos(&h, &[s]);
+        assert_eq!(infos[0].outline_shape_id_ref, 42);
+    }
+
+    #[test]
+    fn default_style_id_falls_back_to_zero_when_style_missing() {
+        // A header with no 바탕글 entry at all (a malformed document)
+        // must still return a sensible u32 rather than panic.
+        let h = HeaderTables::default();
+        assert_eq!(default_style_id(&h), 0);
+    }
+}

--- a/crates/hwp-dvc-core/src/document/run_type/mod.rs
+++ b/crates/hwp-dvc-core/src/document/run_type/mod.rs
@@ -1,0 +1,39 @@
+//! Phase 1c builder: `Vec<RunTypeInfo>` from header tables + section AST.
+//!
+//! This module produces the **validator-facing stream** that every
+//! Phase 2 validator consumes as input. One [`RunTypeInfo`] is emitted
+//! per `<hp:run>` that carries a child list in the OWPML reference
+//! C++ (`OWPMLReader::GetRunTypeInfos`). Here that condition is
+//! approximated by "the run's tag was `<hp:run>...</hp:run>` rather
+//! than `<hp:run/>`" — the section walker (#3) preserves that
+//! distinction by only creating a [`Run`] with an empty text for an
+//! empty element. See [`RUN_TYPE_EMISSION_POLICY`] for the full rule.
+//!
+//! # Scope (this issue, #4)
+//!
+//! The reference populates `pageNo` / `lineNo` by walking
+//! `<hp:linesegarray>` and tracking cumulative vertical position.
+//! That requires a minimal layout engine and is the deferred issue
+//! [#19]. This module leaves both fields at 0 and documents that
+//! explicitly with [`PAGE_LINE_OUT_OF_SCOPE`].
+//!
+//! # Entry point
+//!
+//! [`build_run_type_infos`] is the one function callers use.
+//!
+//! [#19]: https://github.com/inureyes/hwp-dvc/issues/19
+//! [`Run`]: crate::document::section::Run
+
+pub(crate) mod builder;
+
+pub use builder::{
+    build_run_type_infos, default_style_id, IS_IN_SHAPE_SIMPLIFICATION, RUN_TYPE_EMISSION_POLICY,
+};
+
+/// Documentation marker: `pageNo` / `lineNo` are intentionally left at
+/// 0 in this issue. Populating them requires the layout engine
+/// deferred to issue #19 (`feat: page/line numbering for RunTypeInfo`).
+/// Validators that do not depend on pagination can proceed without
+/// these fields; the only consumer is XML output formatting, which is
+/// also in a later issue.
+pub const PAGE_LINE_OUT_OF_SCOPE: &str = "pageNo/lineNo reserved for issue #19 (layout engine)";

--- a/crates/hwp-dvc-core/src/document/section/parser/paragraph.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/paragraph.rs
@@ -30,10 +30,16 @@ use super::table::parse_table;
 /// paragraph starts at depth 0; a cell paragraph inherits the enclosing
 /// table's depth + 1 so that nested tables seen inside it get the
 /// correct `nesting_depth` without a second pass.
+///
+/// `sec_outline_shape_id_ref` is a paragraph-shared sink for the
+/// `<hp:secPr outlineShapeIDRef="...">` value. The section dispatcher
+/// owns the sink; cell paragraphs pass a throwaway sink because
+/// `<hp:secPr>` never appears inside a table cell in practice.
 pub(super) fn parse_paragraph<B: BufRead>(
     reader: &mut Reader<B>,
     start: &BytesStart<'_>,
     depth: u32,
+    sec_outline_shape_id_ref: &mut Option<u32>,
 ) -> DvcResult<Paragraph> {
     let mut para = Paragraph {
         para_pr_id_ref: attr_u32(start.attributes(), b"paraPrIDRef")?,
@@ -54,7 +60,14 @@ pub(super) fn parse_paragraph<B: BufRead>(
         let ev = reader.read_event_into(&mut buf)?;
         match ev {
             Event::Start(ref e) if local_name(e.name()) == b"run" => {
-                parse_run(reader, e, &mut para, depth, &mut in_hyperlink)?;
+                parse_run(
+                    reader,
+                    e,
+                    &mut para,
+                    depth,
+                    &mut in_hyperlink,
+                    sec_outline_shape_id_ref,
+                )?;
             }
             Event::Empty(ref e) if local_name(e.name()) == b"run" => {
                 // Control-only empty run — no children means no text
@@ -80,12 +93,18 @@ pub(super) fn parse_paragraph<B: BufRead>(
 /// `in_hyperlink` is a rolling flag owned by the parent paragraph:
 /// `FieldBegin`/`FieldEnd` markers encountered inside the run toggle
 /// it, and the value at `</run>` time is what the run records.
+///
+/// `sec_outline_shape_id_ref` is set when the run contains a
+/// `<hp:secPr outlineShapeIDRef="...">` control element. Only the
+/// first `<hp:run>` of a section's first `<hp:p>` carries this per
+/// HWPX convention, but the walker captures whichever one appears.
 fn parse_run<B: BufRead>(
     reader: &mut Reader<B>,
     start: &BytesStart<'_>,
     para: &mut Paragraph,
     depth: u32,
     in_hyperlink: &mut bool,
+    sec_outline_shape_id_ref: &mut Option<u32>,
 ) -> DvcResult<()> {
     let char_pr_id_ref = attr_u32(start.attributes(), b"charPrIDRef")?;
     let mut text = String::new();
@@ -111,6 +130,30 @@ fn parse_run<B: BufRead>(
                     *in_hyperlink = false;
                     skip(reader, e)?;
                 }
+                b"secPr" => {
+                    // First occurrence wins: the reference consumer
+                    // walks up ancestors and finds the single
+                    // `<hp:secPr>` attached to the section's opening
+                    // run. Don't overwrite if a later malformed
+                    // document emits a second one.
+                    if sec_outline_shape_id_ref.is_none() {
+                        *sec_outline_shape_id_ref =
+                            Some(attr_u32(e.attributes(), b"outlineShapeIDRef")?);
+                    }
+                    skip(reader, e)?;
+                }
+                b"ctrl" => {
+                    // `<hp:ctrl>` is a transparent container for the
+                    // inline-control markers a run can carry (e.g.
+                    // `<hp:fieldBegin>`, `<hp:fieldEnd>`, `<hp:colPr>`,
+                    // `<hp:bookmark>`). Descend into it and apply the
+                    // same pattern matching that the run body uses so
+                    // that HYPERLINK field markers wrapped inside it
+                    // still toggle the hyperlink flag. Real HWPX
+                    // writers emit field markers wrapped in `<hp:ctrl>`
+                    // unconditionally.
+                    parse_ctrl(reader, in_hyperlink, sec_outline_shape_id_ref)?;
+                }
                 _ => skip(reader, e)?,
             },
             Event::Empty(ref e) => match local_name(e.name()) {
@@ -119,6 +162,10 @@ fn parse_run<B: BufRead>(
                 }
                 b"fieldEnd" if is_hyperlink_field(e)? => {
                     *in_hyperlink = false;
+                }
+                b"secPr" if sec_outline_shape_id_ref.is_none() => {
+                    *sec_outline_shape_id_ref =
+                        Some(attr_u32(e.attributes(), b"outlineShapeIDRef")?);
                 }
                 b"t" => {
                     // Empty text element — nothing to collect.
@@ -138,6 +185,57 @@ fn parse_run<B: BufRead>(
                 return Ok(());
             }
             Event::Eof => return Err(DvcError::Document("unexpected EOF inside <run>".into())),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Descend into an `<hp:ctrl>` wrapper, honoring the field markers
+/// and `<hp:secPr>` that HWPX writers nest inside it. Everything else
+/// (bookmarks, tab stops, column properties, ...) is skipped.
+fn parse_ctrl<B: BufRead>(
+    reader: &mut Reader<B>,
+    in_hyperlink: &mut bool,
+    sec_outline_shape_id_ref: &mut Option<u32>,
+) -> DvcResult<()> {
+    let mut buf = Vec::new();
+    loop {
+        let ev = reader.read_event_into(&mut buf)?;
+        match ev {
+            Event::Start(ref e) => match local_name(e.name()) {
+                b"fieldBegin" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = true;
+                    skip(reader, e)?;
+                }
+                b"fieldEnd" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = false;
+                    skip(reader, e)?;
+                }
+                b"secPr" => {
+                    if sec_outline_shape_id_ref.is_none() {
+                        *sec_outline_shape_id_ref =
+                            Some(attr_u32(e.attributes(), b"outlineShapeIDRef")?);
+                    }
+                    skip(reader, e)?;
+                }
+                _ => skip(reader, e)?,
+            },
+            Event::Empty(ref e) => match local_name(e.name()) {
+                b"fieldBegin" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = true;
+                }
+                b"fieldEnd" if is_hyperlink_field(e)? => {
+                    *in_hyperlink = false;
+                }
+                b"secPr" if sec_outline_shape_id_ref.is_none() => {
+                    *sec_outline_shape_id_ref =
+                        Some(attr_u32(e.attributes(), b"outlineShapeIDRef")?);
+                }
+                _ => {}
+            },
+            Event::End(ref e) if local_name(e.name()) == b"ctrl" => return Ok(()),
+            Event::Eof => return Err(DvcError::Document("unexpected EOF inside <ctrl>".into())),
             _ => {}
         }
         buf.clear();

--- a/crates/hwp-dvc-core/src/document/section/parser/section.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/section.rs
@@ -31,14 +31,26 @@ pub fn parse_section(index: u32, bytes: &[u8]) -> DvcResult<Section> {
 
     let mut section = Section {
         index,
+        outline_shape_id_ref: 0,
         paragraphs: Vec::new(),
     };
 
-    dispatch(&mut reader, &mut section)?;
+    // Collected by `parse_paragraph` -> `parse_run` when it encounters
+    // `<hp:secPr outlineShapeIDRef="..">`. The first occurrence in the
+    // section wins (always the first run of the first paragraph in a
+    // well-formed HWPX).
+    let mut sec_outline_shape_id_ref: Option<u32> = None;
+
+    dispatch(&mut reader, &mut section, &mut sec_outline_shape_id_ref)?;
+    section.outline_shape_id_ref = sec_outline_shape_id_ref.unwrap_or(0);
     Ok(section)
 }
 
-fn dispatch<B: BufRead>(reader: &mut Reader<B>, section: &mut Section) -> DvcResult<()> {
+fn dispatch<B: BufRead>(
+    reader: &mut Reader<B>,
+    section: &mut Section,
+    sec_outline_shape_id_ref: &mut Option<u32>,
+) -> DvcResult<()> {
     let mut buf = Vec::new();
     // nesting_depth = 0 at the section root — any `<hp:tbl>` produced
     // directly inside a top-level paragraph becomes a depth-0 table.
@@ -47,7 +59,7 @@ fn dispatch<B: BufRead>(reader: &mut Reader<B>, section: &mut Section) -> DvcRes
         let ev = reader.read_event_into(&mut buf)?;
         match ev {
             Event::Start(ref e) if local_name(e.name()) == b"p" => {
-                let para = parse_paragraph(reader, e, base_depth)?;
+                let para = parse_paragraph(reader, e, base_depth, sec_outline_shape_id_ref)?;
                 section.paragraphs.push(para);
             }
             Event::Empty(ref e) if local_name(e.name()) == b"p" => {

--- a/crates/hwp-dvc-core/src/document/section/parser/table.rs
+++ b/crates/hwp-dvc-core/src/document/section/parser/table.rs
@@ -133,11 +133,17 @@ fn parse_sub_list<B: BufRead>(
     depth: u32,
 ) -> DvcResult<()> {
     let mut buf = Vec::new();
+    // `<hp:secPr>` never appears inside a table cell in a well-formed
+    // HWPX — it is section-scoped and sits in the first run of the
+    // first top-level paragraph. A per-cell throwaway sink keeps the
+    // `parse_paragraph` signature uniform while discarding any
+    // spurious match.
+    let mut discard_outline_ref: Option<u32> = None;
     loop {
         let ev = reader.read_event_into(&mut buf)?;
         match ev {
             Event::Start(ref e) if local_name(e.name()) == b"p" => {
-                let para = parse_paragraph(reader, e, depth)?;
+                let para = parse_paragraph(reader, e, depth, &mut discard_outline_ref)?;
                 out.push(para);
             }
             Event::Empty(ref e) if local_name(e.name()) == b"p" => {

--- a/crates/hwp-dvc-core/src/document/section/types/nodes.rs
+++ b/crates/hwp-dvc-core/src/document/section/types/nodes.rs
@@ -39,6 +39,16 @@ pub struct Section {
     /// so that downstream code can re-emit the original file path in
     /// error messages.
     pub index: u32,
+    /// `outlineShapeIDRef` attribute of the `<hp:secPr>` that sits
+    /// inside the first `<hp:run>` of the first `<hp:p>`. This is a
+    /// section-wide value that Phase 1c (#4) copies onto every
+    /// `RunTypeInfo` in the section — mirroring the C++ reference's
+    /// `OWPMLReader::GetRunTypeInfos` which resolves it via
+    /// `FindObjectFromParents(pPType, ID_PARA_SectionDefinitionType)`.
+    /// Defaults to 0 if the section has no `<hp:secPr>` (which only
+    /// happens for malformed HWPX; well-formed writers always emit
+    /// it on the section's first run).
+    pub outline_shape_id_ref: u32,
     /// Paragraphs in document order.
     pub paragraphs: Vec<Paragraph>,
 }

--- a/crates/hwp-dvc-core/tests/run_type_info.rs
+++ b/crates/hwp-dvc-core/tests/run_type_info.rs
@@ -1,0 +1,234 @@
+//! Integration tests for `Document::parse()` → `Vec<RunTypeInfo>`
+//! against real HWPX fixtures committed under `tests/fixtures/docs/`.
+//!
+//! Each test opens a fixture end-to-end with [`Document::open`],
+//! calls [`Document::parse`], and asserts a concrete domain fact on
+//! the resulting `run_type_infos` stream.
+//!
+//! | Fixture                | Assertion                                                             |
+//! |------------------------|-----------------------------------------------------------------------|
+//! | `charshape_pass`       | at least one plain run with 함초롬바탕 charshape, no table, no link.  |
+//! | `table_nested`         | at least one run inside a table; at least one inside a nested table.  |
+//! | `hyperlink_external`   | at least one run flagged `is_hyperlink = true`.                       |
+//!
+//! The fixture-paired spec (`tests/fixtures/specs/fixture_spec.json`)
+//! is not loaded here — the run-type builder is spec-agnostic; spec
+//! wiring is tested by the validator integrations in later issues.
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::document::header::FontLang;
+use hwp_dvc_core::document::{Document, RunTypeInfo};
+
+/// Absolute path to a fixture under `tests/fixtures/docs/`.
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("docs");
+    p.push(name);
+    p
+}
+
+fn parse(name: &str) -> Document {
+    let mut doc = Document::open(fixture(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture {name}: {e}"));
+    doc
+}
+
+/// Return `true` if `s` contains at least one character in the
+/// Korean syllable range (U+AC00..=U+D7A3).
+fn contains_korean(s: &str) -> bool {
+    s.chars().any(|c| ('\u{AC00}'..='\u{D7A3}').contains(&c))
+}
+
+#[test]
+fn charshape_pass_produces_plain_run_with_hamcho_font() {
+    let doc = parse("charshape_pass.hwpx");
+    let header = doc
+        .header
+        .as_ref()
+        .expect("Document::parse must populate the header");
+
+    assert!(
+        !doc.run_type_infos.is_empty(),
+        "charshape_pass must expose at least one RunTypeInfo"
+    );
+
+    // At least one run must have non-empty Korean text, sit outside
+    // any table/hyperlink, and resolve its charshape to a set that
+    // includes 함초롬바탕.
+    let candidate: &RunTypeInfo = doc
+        .run_type_infos
+        .iter()
+        .find(|r| {
+            !r.text.is_empty()
+                && !r.is_in_table
+                && !r.is_hyperlink
+                && contains_korean(&r.text)
+                && header
+                    .char_shapes
+                    .get(&r.char_pr_id_ref)
+                    .map(|cs| {
+                        cs.font_names(&header.font_faces)
+                            .iter()
+                            .any(|n| n == "함초롬바탕")
+                    })
+                    .unwrap_or(false)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected at least one plain non-table, non-hyperlink run with 함초롬바탕 \
+                 charshape; got: {:?}",
+                doc.run_type_infos
+                    .iter()
+                    .map(|r| (
+                        r.text.clone(),
+                        r.char_pr_id_ref,
+                        r.is_in_table,
+                        r.is_hyperlink
+                    ))
+                    .collect::<Vec<_>>()
+            )
+        });
+
+    // Spot-check the flags on the same run, matching the fixture's
+    // single-paragraph shape.
+    assert!(
+        !candidate.is_in_table_in_table,
+        "charshape_pass has no tables at all"
+    );
+    assert_eq!(
+        candidate.page_no, 0,
+        "page_no must be 0 in this issue (layout deferred to #19)"
+    );
+    assert_eq!(
+        candidate.line_no, 0,
+        "line_no must be 0 in this issue (layout deferred to #19)"
+    );
+
+    // Sanity: the Hangul font of the charshape this run references
+    // resolves to 함초롬바탕, mirroring what the header test asserts
+    // at the table level.
+    assert_eq!(
+        header.font_name(candidate.char_pr_id_ref, FontLang::Hangul),
+        Some("함초롬바탕"),
+        "the chosen run's Hangul font must be 함초롬바탕"
+    );
+}
+
+#[test]
+fn table_nested_flags_runs_inside_tables() {
+    let doc = parse("table_nested.hwpx");
+
+    assert!(
+        !doc.run_type_infos.is_empty(),
+        "table_nested must expose at least one RunTypeInfo"
+    );
+
+    // At least one run must be flagged `is_in_table` — a cell of
+    // either the outer or the inner table will satisfy this.
+    assert!(
+        doc.run_type_infos.iter().any(|r| r.is_in_table),
+        "expected at least one RunTypeInfo with is_in_table=true; got: {:?}",
+        doc.run_type_infos
+            .iter()
+            .map(|r| (r.text.clone(), r.is_in_table, r.is_in_table_in_table))
+            .collect::<Vec<_>>()
+    );
+
+    // At least one run must be flagged `is_in_table_in_table` —
+    // specifically the fixture's inner 1x1 table inside the outer
+    // 2x2 cell (1,1). The section-parsing test already guarantees
+    // the nesting depth is recorded; here we assert it propagates
+    // through to the RunTypeInfo stream.
+    assert!(
+        doc.run_type_infos.iter().any(|r| r.is_in_table_in_table),
+        "expected at least one RunTypeInfo with is_in_table_in_table=true; got: {:?}",
+        doc.run_type_infos
+            .iter()
+            .filter(|r| r.is_in_table)
+            .map(|r| (
+                r.text.clone(),
+                r.table_id,
+                r.table_row,
+                r.table_col,
+                r.is_in_table_in_table
+            ))
+            .collect::<Vec<_>>()
+    );
+
+    // A run inside an inner table must also be flagged `is_in_table`
+    // (not just `is_in_table_in_table`). If we ever decouple those
+    // semantics this assertion catches it.
+    for r in &doc.run_type_infos {
+        if r.is_in_table_in_table {
+            assert!(
+                r.is_in_table,
+                "is_in_table_in_table implies is_in_table; got text={:?}",
+                r.text
+            );
+        }
+    }
+
+    // Sanity: runs outside tables exist too (the fixture's opening
+    // paragraph before the table). Guards against a regression that
+    // accidentally marks every run as table-bound.
+    assert!(
+        doc.run_type_infos.iter().any(|r| !r.is_in_table),
+        "expected at least one top-level (non-table) RunTypeInfo in table_nested"
+    );
+}
+
+#[test]
+fn hyperlink_external_flags_hyperlink_run() {
+    let doc = parse("hyperlink_external.hwpx");
+
+    assert!(
+        !doc.run_type_infos.is_empty(),
+        "hyperlink_external must expose at least one RunTypeInfo"
+    );
+
+    let hyperlink_runs: Vec<&RunTypeInfo> = doc
+        .run_type_infos
+        .iter()
+        .filter(|r| r.is_hyperlink)
+        .collect();
+
+    assert!(
+        !hyperlink_runs.is_empty(),
+        "expected at least one RunTypeInfo with is_hyperlink=true; got texts: {:?}",
+        doc.run_type_infos
+            .iter()
+            .map(|r| (r.text.clone(), r.is_hyperlink))
+            .collect::<Vec<_>>()
+    );
+
+    // A hyperlink run should not simultaneously be flagged as being
+    // inside a table for this fixture — it is a plain-paragraph
+    // hyperlink. Guards against the flag-propagation code
+    // accidentally OR-ing unrelated flags.
+    for r in hyperlink_runs {
+        assert!(
+            !r.is_in_table,
+            "hyperlink run unexpectedly flagged in-table: {:?}",
+            r.text
+        );
+    }
+}
+
+#[test]
+fn parse_is_idempotent_and_replaces_prior_state() {
+    let mut doc = Document::open(fixture("charshape_pass.hwpx")).expect("open ok");
+    doc.parse().expect("first parse ok");
+    let first_count = doc.run_type_infos.len();
+    doc.parse().expect("second parse ok");
+    assert_eq!(
+        doc.run_type_infos.len(),
+        first_count,
+        "Document::parse must be idempotent — repeated calls yield the same RunTypeInfo count"
+    );
+    assert!(doc.header.is_some(), "header must remain populated");
+}


### PR DESCRIPTION
## Summary

Close out Phase 1 by implementing `Document::parse()` end-to-end.
Combines the header tables (#2) and the section AST (#3) into the
`Vec<RunTypeInfo>` stream every Phase 2 validator will consume.

## Acceptance checklist (per issue #4)

- [x] `Document::parse()` no longer returns `NotImplemented`; produces `Vec<RunTypeInfo>`.
- [x] Hyperlink and style control characters are detected and flip the corresponding flags.
- [x] `is_in_table_in_table` correctly set using nesting depth from #3.
- [x] Integration test: given a tiny HWPX fixture, the produced `RunTypeInfo` list matches expected domain facts.

## Scope & deferred fields

- `page_no` / `line_no` are intentionally 0. Layout-engine-based page/line numbering is deferred to issue #19. Documented on both `RunTypeInfo` and via `run_type::PAGE_LINE_OUT_OF_SCOPE`.
- `is_in_shape` stays `false`. `<hp:drawText>` ancestor tracking is not surfaced by the Section AST yet; the Phase 2 validator that cares will add it in its own PR. Documented via `run_type::IS_IN_SHAPE_SIMPLIFICATION`.
- `is_style` checks against the header's resolved id for 바탕글 (via `style_by_name`) instead of hard-coding 0, per the issue guidance.
- `outline_shape_id_ref` is resolved from `<hp:secPr>` and carried as a section-level field — mirroring the C++ reference's `GetRunTypeInfos` behavior (`FindObjectFromParents(pPType, ID_PARA_SectionDefinitionType)`).

## Enabling parser changes

- `Section` gained an `outline_shape_id_ref: u32` field. The section walker captures it from the first `<hp:run>` of the first `<hp:p>` through a sink threaded down `parse_paragraph`/`parse_run`.
- The run walker now descends into `<hp:ctrl>` wrappers. Real HWPX writers wrap `<hp:fieldBegin type=\"HYPERLINK\">` and `<hp:secPr>` inside `<hp:ctrl>`; the previous walker skipped those subtrees, so hyperlink flags silently stayed off on the `hyperlink_external.hwpx` fixture.

## Fixtures used

End-to-end integration tests live in `crates/hwp-dvc-core/tests/run_type_info.rs`:

| Fixture | Assertion |
|---------|-----------|
| `charshape_pass.hwpx` | at least one plain run (no table, no hyperlink) whose charshape includes 함초롬바탕 |
| `table_nested.hwpx` | at least one `is_in_table=true` run and at least one `is_in_table_in_table=true` run |
| `hyperlink_external.hwpx` | at least one `is_hyperlink=true` run |

Plus an idempotency test that guards against state-mutation bugs on repeated `parse()` calls.

## Verification

- `cargo test --workspace` — 36 tests pass across 5 integration test files + lib unit tests.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Every new source file stays under the 500-line cap (builder is 425, tests 234, module glue trivial).