### PR TITLE
feat: implement CheckHyperlink validator (closes #6)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
@@ -1,0 +1,140 @@
+//! Hyperlink validator.
+//!
+//! Maps to `CheckHyperlink` in `references/dvc/Checker.cpp`.
+//!
+//! When the spec contains `"hyperlink": { "permission": false }`, every
+//! run flagged `is_hyperlink == true` in the [`RunTypeInfo`] stream is
+//! reported as a [`DvcErrorInfo`] with `error_code`
+//! [`HYPERLINK_PERMISSION`] (6901).
+
+use crate::checker::DvcErrorInfo;
+use crate::document::RunTypeInfo;
+use crate::error::ErrorCode;
+use crate::spec::HyperlinkSpec;
+
+/// Error code for a forbidden hyperlink run.
+///
+/// The [`ErrorCode::Hyperlink`] base is 6900; this constant occupies
+/// the first slot (6901), matching the reference C++ `CHyperlink`.
+pub const HYPERLINK_PERMISSION: u32 = ErrorCode::Hyperlink as u32 + 1;
+
+/// Walk `run_type_infos` and emit one [`DvcErrorInfo`] per hyperlink
+/// run when `spec.permission == false`.
+///
+/// Returns an empty `Vec` when either `spec.permission == true` (hyperlinks
+/// are allowed) or no run is flagged `is_hyperlink`.
+pub fn check(spec: &HyperlinkSpec, run_type_infos: &[RunTypeInfo]) -> Vec<DvcErrorInfo> {
+    if spec.permission {
+        return Vec::new();
+    }
+
+    run_type_infos
+        .iter()
+        .filter(|run| run.is_hyperlink)
+        .map(|run| DvcErrorInfo {
+            char_pr_id_ref: run.char_pr_id_ref,
+            para_pr_id_ref: run.para_pr_id_ref,
+            text: run.text.clone(),
+            page_no: run.page_no,
+            line_no: run.line_no,
+            error_code: HYPERLINK_PERMISSION,
+            table_id: run.table_id,
+            is_in_table: run.is_in_table,
+            is_in_table_in_table: run.is_in_table_in_table,
+            table_row: run.table_row,
+            table_col: run.table_col,
+            is_in_shape: run.is_in_shape,
+            use_hyperlink: true,
+            use_style: false,
+            error_string: String::new(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::RunTypeInfo;
+    use crate::spec::HyperlinkSpec;
+
+    fn hyperlink_run() -> RunTypeInfo {
+        RunTypeInfo {
+            is_hyperlink: true,
+            text: "click me".to_owned(),
+            char_pr_id_ref: 1,
+            ..Default::default()
+        }
+    }
+
+    fn plain_run() -> RunTypeInfo {
+        RunTypeInfo {
+            is_hyperlink: false,
+            text: "plain text".to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn permission_true_emits_no_errors() {
+        let spec = HyperlinkSpec { permission: true };
+        let runs = vec![hyperlink_run(), plain_run()];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "permission=true must never produce errors; got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn permission_false_emits_error_for_hyperlink_run() {
+        let spec = HyperlinkSpec { permission: false };
+        let runs = vec![hyperlink_run(), plain_run()];
+        let errors = check(&spec, &runs);
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one error for one hyperlink run; got {errors:?}"
+        );
+        assert_eq!(errors[0].error_code, HYPERLINK_PERMISSION);
+        assert!(errors[0].use_hyperlink);
+        assert_eq!(errors[0].text, "click me");
+    }
+
+    #[test]
+    fn permission_false_no_hyperlinks_emits_no_errors() {
+        let spec = HyperlinkSpec { permission: false };
+        let runs = vec![plain_run(), plain_run()];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "no hyperlink runs means no errors; got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn permission_false_multiple_hyperlinks_emits_one_error_each() {
+        let spec = HyperlinkSpec { permission: false };
+        let runs = vec![hyperlink_run(), hyperlink_run(), plain_run()];
+        let errors = check(&spec, &runs);
+        assert_eq!(
+            errors.len(),
+            2,
+            "two hyperlink runs produce two errors; got {errors:?}"
+        );
+        for e in &errors {
+            assert_eq!(e.error_code, HYPERLINK_PERMISSION);
+        }
+    }
+
+    #[test]
+    fn error_code_is_in_hyperlink_range() {
+        assert!(
+            HYPERLINK_PERMISSION >= ErrorCode::Hyperlink as u32,
+            "HYPERLINK_PERMISSION must be >= 6900"
+        );
+        assert!(
+            HYPERLINK_PERMISSION < ErrorCode::Macro as u32,
+            "HYPERLINK_PERMISSION must be < 7000 (next category)"
+        );
+    }
+}

--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -4,6 +4,7 @@
 //! Maps to `Checker` in `references/dvc/Checker.h`. Each `Check*`
 //! method in the C++ version becomes an associated function here.
 
+pub mod hyperlink;
 pub mod style;
 
 use crate::document::Document;
@@ -65,20 +66,32 @@ pub struct Checker<'a> {
 
 impl<'a> Checker<'a> {
     pub fn new(spec: &'a DvcSpec, document: &'a Document) -> Self {
-        Self { spec, document, level: CheckLevel::default(), scope: OutputScope::default() }
+        Self {
+            spec,
+            document,
+            level: CheckLevel::default(),
+            scope: OutputScope::default(),
+        }
     }
 
     /// Run every enabled check and return the collected errors.
     ///
     /// TODO: port `CheckCharShape`, `CheckParaShape`, `CheckTable`,
     /// `CheckSpacialCharacter`, `CheckOutlineShape`, `CheckBullet`,
-    /// `CheckParaNumBullet`, `CheckHyperlink`, `CheckStyle`,
-    /// `CheckMacro` from `references/dvc/Checker.cpp`.
+    /// `CheckParaNumBullet`, `CheckMacro` from
+    /// `references/dvc/Checker.cpp`.
     pub fn run(&self) -> DvcResult<Vec<DvcErrorInfo>> {
         let mut errors: Vec<DvcErrorInfo> = Vec::new();
+
+        // CheckHyperlink — report forbidden hyperlink runs.
+        if let Some(spec) = &self.spec.hyperlink {
+            errors.extend(hyperlink::check(spec, &self.document.run_type_infos));
+        }
+
         if let Some(style_spec) = &self.spec.style {
             errors.extend(style::check(style_spec, &self.document.run_type_infos));
         }
+
         Ok(errors)
     }
 }

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -56,3 +56,9 @@ pub enum ErrorCode {
     Hyperlink = 6900,
     Macro = 7000,
 }
+
+/// Specific error codes within the [`ErrorCode::Hyperlink`] (6900) range.
+pub mod hyperlink_codes {
+    /// A run is flagged as a hyperlink but the spec forbids hyperlinks.
+    pub const HYPERLINK_PERMISSION: u32 = 6901;
+}

--- a/crates/hwp-dvc-core/tests/check_hyperlink.rs
+++ b/crates/hwp-dvc-core/tests/check_hyperlink.rs
@@ -1,0 +1,147 @@
+//! Integration tests for the hyperlink validator.
+//!
+//! Exercises the full pipeline: `Document::parse` → `Checker::run` with
+//! a real fixture and a spec loaded from `fixture_spec.json`.
+//!
+//! | Fixture                | Spec                              | Expected                               |
+//! |------------------------|-----------------------------------|----------------------------------------|
+//! | `hyperlink_none.hwpx`  | `"hyperlink": {"permission": false}` | zero Hyperlink-range errors         |
+//! | `hyperlink_external.hwpx` | `"hyperlink": {"permission": false}` | ≥ 1 error with code 6901        |
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::{Checker, DvcErrorInfo};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::error::ErrorCode;
+use hwp_dvc_core::spec::DvcSpec;
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn parse_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture {name}: {e}"));
+    doc
+}
+
+fn load_spec() -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec("fixture_spec.json"))
+        .expect("fixture_spec.json should parse cleanly")
+}
+
+fn hyperlink_errors(errors: &[DvcErrorInfo]) -> Vec<&DvcErrorInfo> {
+    let base = ErrorCode::Hyperlink as u32;
+    let next = ErrorCode::Macro as u32;
+    errors
+        .iter()
+        .filter(|e| e.error_code >= base && e.error_code < next)
+        .collect()
+}
+
+/// A document with no hyperlinks must produce zero Hyperlink-range errors
+/// even when the spec forbids hyperlinks.
+#[test]
+fn hyperlink_none_produces_zero_hyperlink_errors() {
+    let doc = parse_doc("hyperlink_none.hwpx");
+    let spec = load_spec();
+
+    // Confirm the spec actually forbids hyperlinks.
+    let hl_spec = spec
+        .hyperlink
+        .as_ref()
+        .expect("fixture_spec must have hyperlink section");
+    assert!(
+        !hl_spec.permission,
+        "fixture_spec must set hyperlink.permission = false for this test to be meaningful"
+    );
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("Checker::run must not fail");
+    let hl_errors = hyperlink_errors(&errors);
+
+    assert!(
+        hl_errors.is_empty(),
+        "hyperlink_none.hwpx has no hyperlinks — expected zero errors in range 6900..6999; \
+         got {} errors: {hl_errors:?}",
+        hl_errors.len()
+    );
+}
+
+/// A document with an external hyperlink must produce at least one error
+/// in the 6900 range when the spec forbids hyperlinks.
+#[test]
+fn hyperlink_external_produces_hyperlink_errors() {
+    let doc = parse_doc("hyperlink_external.hwpx");
+    let spec = load_spec();
+
+    // Sanity: the fixture must actually contain hyperlink runs.
+    let hl_run_count = doc.run_type_infos.iter().filter(|r| r.is_hyperlink).count();
+    assert!(
+        hl_run_count > 0,
+        "hyperlink_external.hwpx must contain at least one hyperlink run for this test \
+         to be meaningful; got 0"
+    );
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("Checker::run must not fail");
+    let hl_errors = hyperlink_errors(&errors);
+
+    assert!(
+        !hl_errors.is_empty(),
+        "hyperlink_external.hwpx has {hl_run_count} hyperlink run(s) and spec forbids hyperlinks \
+         — expected ≥ 1 error in range 6900..6999; got none"
+    );
+
+    // Every hyperlink error must carry use_hyperlink = true.
+    for e in &hl_errors {
+        assert!(
+            e.use_hyperlink,
+            "all hyperlink errors must have use_hyperlink=true; got {e:?}"
+        );
+    }
+
+    // The error count must match the number of flagged hyperlink runs.
+    assert_eq!(
+        hl_errors.len(),
+        hl_run_count,
+        "expected one error per hyperlink run ({hl_run_count} runs); got {}",
+        hl_errors.len()
+    );
+}
+
+/// Verify that `Checker::run` emits no hyperlink errors when the spec
+/// permits hyperlinks, even for a document that contains them.
+#[test]
+fn hyperlink_permitted_emits_no_errors() {
+    use hwp_dvc_core::spec::HyperlinkSpec;
+
+    let doc = parse_doc("hyperlink_external.hwpx");
+
+    // Build a minimal spec that explicitly *allows* hyperlinks.
+    let spec = DvcSpec {
+        hyperlink: Some(HyperlinkSpec { permission: true }),
+        ..Default::default()
+    };
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("Checker::run must not fail");
+    let hl_errors = hyperlink_errors(&errors);
+
+    assert!(
+        hl_errors.is_empty(),
+        "permission=true must suppress all hyperlink errors; got {hl_errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `crates/hwp-dvc-core/src/checker/hyperlink/mod.rs` with `check(spec, run_type_infos)` that emits `DvcErrorInfo` with `error_code = 6901` for every run where `is_hyperlink == true` when `spec.permission == false`.
- Wire `hyperlink::check` into `Checker::run` via `pub mod hyperlink` in `checker/mod.rs`.
- Append `hyperlink_codes::HYPERLINK_PERMISSION = 6901` constant to `error.rs`.
- Add integration test `tests/check_hyperlink.rs` with three tests covering the pass/fail/permit cases using `hyperlink_none.hwpx` and `hyperlink_external.hwpx` through the full `Document::parse → Checker::run` pipeline.

## Test plan

- [x] `hyperlink_none.hwpx` + `fixture_spec.json` (permission=false) → zero 6900-range errors
- [x] `hyperlink_external.hwpx` + `fixture_spec.json` (permission=false) → one error per hyperlink run
- [x] `hyperlink_external.hwpx` + permission=true spec → zero errors
- [x] Five unit tests inside `checker::hyperlink` cover allow/deny edge cases
- [x] `cargo test --workspace` passes (41 tests total)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes