### PR TITLE
feat: implement CheckStyle validator (closes #5)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -4,6 +4,8 @@
 //! Maps to `Checker` in `references/dvc/Checker.h`. Each `Check*`
 //! method in the C++ version becomes an associated function here.
 
+pub mod style;
+
 use crate::document::Document;
 use crate::error::DvcResult;
 use crate::spec::DvcSpec;
@@ -73,6 +75,10 @@ impl<'a> Checker<'a> {
     /// `CheckParaNumBullet`, `CheckHyperlink`, `CheckStyle`,
     /// `CheckMacro` from `references/dvc/Checker.cpp`.
     pub fn run(&self) -> DvcResult<Vec<DvcErrorInfo>> {
-        Ok(Vec::new())
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        if let Some(style_spec) = &self.spec.style {
+            errors.extend(style::check(style_spec, &self.document.run_type_infos));
+        }
+        Ok(errors)
     }
 }

--- a/crates/hwp-dvc-core/src/checker/style/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/style/mod.rs
@@ -1,0 +1,176 @@
+//! `CheckStyle` validator — mirrors `Checker::CheckStyle` in the
+//! reference C++ implementation (`references/dvc/Checker.cpp`).
+//!
+//! # Logic
+//!
+//! When the spec carries `"style": { "permission": false }`, every
+//! [`RunTypeInfo`] whose `is_style == true` (i.e. whose paragraph was
+//! formatted with a non-default style, meaning any style other than
+//! "바탕글") produces one [`DvcErrorInfo`] with `error_code` in the
+//! [`ErrorCode::Style`] (3500) range.
+//!
+//! When `permission == true`, no errors are emitted — the document is
+//! free to use custom styles.
+//!
+//! The error code emitted per run is [`STYLE_PERMISSION`] (3502),
+//! following the reference's scheme where 3500 is the category base
+//! and individual sub-codes are offset from it.
+//!
+//! [`RunTypeInfo`]: crate::document::RunTypeInfo
+
+use crate::checker::DvcErrorInfo;
+use crate::document::RunTypeInfo;
+use crate::error::ErrorCode;
+use crate::spec::StyleSpec;
+
+/// Concrete error code emitted when a run uses a non-default style and
+/// `StyleSpec.permission == false`. Offset from the `Style` base (3500)
+/// to leave room for the category base itself and a future "allowed
+/// style list" code at 3501.
+pub const STYLE_PERMISSION: u32 = ErrorCode::Style as u32 + 2;
+
+/// Run the style check over a slice of [`RunTypeInfo`]s.
+///
+/// # Parameters
+/// - `spec`  — the `StyleSpec` extracted from the user's DVC JSON file.
+/// - `runs`  — the flattened run stream produced by
+///   [`crate::document::run_type::build_run_type_infos`].
+///
+/// # Returns
+/// A `Vec<DvcErrorInfo>` — empty when `spec.permission == true` or when
+/// no run uses a custom style. Each entry's `error_code` is
+/// [`STYLE_PERMISSION`] and `use_style` is set to `true`.
+#[must_use]
+pub fn check(spec: &StyleSpec, runs: &[RunTypeInfo]) -> Vec<DvcErrorInfo> {
+    if spec.permission {
+        // Styles are permitted: nothing to report.
+        return Vec::new();
+    }
+
+    runs.iter()
+        .filter(|r| r.is_style)
+        .map(|r| DvcErrorInfo {
+            char_pr_id_ref: r.char_pr_id_ref,
+            para_pr_id_ref: r.para_pr_id_ref,
+            text: r.text.clone(),
+            page_no: r.page_no,
+            line_no: r.line_no,
+            error_code: STYLE_PERMISSION,
+            table_id: r.table_id,
+            is_in_table: r.is_in_table,
+            is_in_table_in_table: r.is_in_table_in_table,
+            table_row: r.table_row,
+            table_col: r.table_col,
+            is_in_shape: r.is_in_shape,
+            use_hyperlink: r.is_hyperlink,
+            use_style: true,
+            error_string: String::new(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::RunTypeInfo;
+    use crate::spec::StyleSpec;
+
+    fn run_with_style(is_style: bool) -> RunTypeInfo {
+        RunTypeInfo {
+            is_style,
+            text: "테스트".into(),
+            char_pr_id_ref: 1,
+            para_pr_id_ref: 0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn permission_true_emits_no_errors() {
+        let spec = StyleSpec { permission: true };
+        let runs = vec![run_with_style(true), run_with_style(false)];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "permission=true must not produce any Style errors"
+        );
+    }
+
+    #[test]
+    fn permission_false_emits_error_for_styled_runs() {
+        let spec = StyleSpec { permission: false };
+        let runs = vec![
+            run_with_style(true),
+            run_with_style(false),
+            run_with_style(true),
+        ];
+        let errors = check(&spec, &runs);
+        assert_eq!(
+            errors.len(),
+            2,
+            "exactly two runs have is_style=true, so two errors expected"
+        );
+        for e in &errors {
+            assert_eq!(
+                e.error_code, STYLE_PERMISSION,
+                "error_code must be STYLE_PERMISSION ({})",
+                STYLE_PERMISSION
+            );
+            assert!(e.use_style, "use_style flag must be set");
+        }
+    }
+
+    #[test]
+    fn permission_false_no_styled_runs_emits_no_errors() {
+        let spec = StyleSpec { permission: false };
+        let runs = vec![run_with_style(false), run_with_style(false)];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "no styled runs means no errors even when permission=false"
+        );
+    }
+
+    #[test]
+    fn error_fields_mirror_run_fields() {
+        let spec = StyleSpec { permission: false };
+        let run = RunTypeInfo {
+            is_style: true,
+            text: "스타일텍스트".into(),
+            char_pr_id_ref: 7,
+            para_pr_id_ref: 3,
+            is_in_table: true,
+            table_id: 42,
+            table_row: 1,
+            table_col: 2,
+            is_hyperlink: false,
+            ..Default::default()
+        };
+        let errors = check(&spec, &[run]);
+        assert_eq!(errors.len(), 1);
+        let e = &errors[0];
+        assert_eq!(e.text, "스타일텍스트");
+        assert_eq!(e.char_pr_id_ref, 7);
+        assert_eq!(e.para_pr_id_ref, 3);
+        assert!(e.is_in_table);
+        assert_eq!(e.table_id, 42);
+        assert_eq!(e.table_row, 1);
+        assert_eq!(e.table_col, 2);
+        assert!(!e.use_hyperlink);
+        assert!(e.use_style);
+        assert_eq!(e.error_code, STYLE_PERMISSION);
+    }
+
+    #[test]
+    fn style_permission_constant_is_in_style_range() {
+        // Guard: STYLE_PERMISSION must be in [3500, 3600).
+        assert!(
+            STYLE_PERMISSION >= ErrorCode::Style as u32,
+            "STYLE_PERMISSION must be >= Style base (3500)"
+        );
+        assert!(
+            STYLE_PERMISSION < ErrorCode::Page as u32,
+            "STYLE_PERMISSION must be < next category (Page=4000)"
+        );
+    }
+}

--- a/crates/hwp-dvc-core/tests/check_style.rs
+++ b/crates/hwp-dvc-core/tests/check_style.rs
@@ -1,0 +1,174 @@
+//! Integration tests for the `CheckStyle` validator.
+//!
+//! Each test follows the full pipeline:
+//!   `Document::open` → `Document::parse` → `Checker::new` → `Checker::run`
+//!
+//! Fixtures under `tests/fixtures/docs/` are real HWPX archives that have
+//! been committed with the repository. The shared spec is loaded from
+//! `tests/fixtures/specs/fixture_spec.json` which carries
+//! `"style": { "permission": false }`.
+//!
+//! | Fixture                 | Expected outcome                                          |
+//! |-------------------------|-----------------------------------------------------------|
+//! | `style_default_only`    | zero Style-range errors (no custom styles used)           |
+//! | `style_custom`          | ≥ 1 Style-range error (custom style used, disallowed)     |
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::style::STYLE_PERMISSION;
+use hwp_dvc_core::checker::{Checker, DvcErrorInfo};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::error::ErrorCode;
+use hwp_dvc_core::spec::DvcSpec;
+
+/// Absolute path to a HWPX fixture.
+fn doc_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+/// Absolute path to a spec fixture.
+fn spec_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+/// Load, parse, and run the checker against a fixture document+spec pair.
+/// Returns the full error list from `Checker::run`.
+fn check(doc_name: &str, spec_name: &str) -> Vec<DvcErrorInfo> {
+    let spec = DvcSpec::from_json_file(spec_fixture(spec_name))
+        .unwrap_or_else(|e| panic!("failed to parse spec {spec_name}: {e}"));
+
+    let mut doc = Document::open(doc_fixture(doc_name))
+        .unwrap_or_else(|e| panic!("failed to open {doc_name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse {doc_name}: {e}"));
+
+    let checker = Checker::new(&spec, &doc);
+    checker
+        .run()
+        .unwrap_or_else(|e| panic!("Checker::run failed for {doc_name}: {e}"))
+}
+
+/// Partition `errors` into Style-range errors (3500 ≤ code < 4000) and others.
+fn partition_style_errors(errors: &[DvcErrorInfo]) -> (Vec<&DvcErrorInfo>, Vec<&DvcErrorInfo>) {
+    let style_base = ErrorCode::Style as u32;
+    let next_base = ErrorCode::Page as u32;
+    errors
+        .iter()
+        .partition(|e| e.error_code >= style_base && e.error_code < next_base)
+}
+
+// ---------------------------------------------------------------------------
+// Passing fixture: style_default_only.hwpx
+// ---------------------------------------------------------------------------
+
+/// A document that only uses the default "바탕글" style must produce
+/// zero Style-range errors when `permission == false`.
+#[test]
+fn style_default_only_produces_no_style_errors() {
+    let errors = check("style_default_only.hwpx", "fixture_spec.json");
+    let (style_errors, _) = partition_style_errors(&errors);
+    assert!(
+        style_errors.is_empty(),
+        "style_default_only must have zero Style-range errors; got {style_errors:?}"
+    );
+}
+
+/// The `style_default_only` fixture must also produce zero `use_style=true`
+/// entries — the run stream carries no `is_style=true` runs.
+#[test]
+fn style_default_only_no_use_style_flags() {
+    let errors = check("style_default_only.hwpx", "fixture_spec.json");
+    let flagged: Vec<&DvcErrorInfo> = errors.iter().filter(|e| e.use_style).collect();
+    assert!(
+        flagged.is_empty(),
+        "style_default_only must produce no DvcErrorInfo with use_style=true; got {flagged:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failing fixture: style_custom.hwpx
+// ---------------------------------------------------------------------------
+
+/// A document that applies a custom style must produce at least one
+/// Style-range error when `permission == false`.
+#[test]
+fn style_custom_produces_at_least_one_style_error() {
+    let errors = check("style_custom.hwpx", "fixture_spec.json");
+    let (style_errors, _) = partition_style_errors(&errors);
+    assert!(
+        !style_errors.is_empty(),
+        "style_custom must have ≥ 1 Style-range error when permission=false; got zero errors"
+    );
+}
+
+/// Every Style-range error emitted for `style_custom` must carry
+/// `error_code == STYLE_PERMISSION` and `use_style == true`.
+#[test]
+fn style_custom_error_fields_are_correct() {
+    let errors = check("style_custom.hwpx", "fixture_spec.json");
+    let (style_errors, _) = partition_style_errors(&errors);
+    assert!(
+        !style_errors.is_empty(),
+        "style_custom must emit style errors"
+    );
+    for e in &style_errors {
+        assert_eq!(
+            e.error_code, STYLE_PERMISSION,
+            "error_code must be STYLE_PERMISSION ({STYLE_PERMISSION}); got {}",
+            e.error_code
+        );
+        assert!(
+            e.use_style,
+            "use_style must be true on a Style-range error; got {e:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Permission-true guard: style_custom should be clean when permission=true
+// ---------------------------------------------------------------------------
+
+/// When the spec permits styles (`permission: true`), even `style_custom`
+/// must produce zero Style-range errors — the validator must be a no-op.
+#[test]
+fn style_custom_clean_when_permission_true() {
+    // Build an in-memory spec that enables styles.
+    let spec_json = r#"{ "style": { "permission": true } }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("inline spec parses");
+
+    let mut doc = Document::open(doc_fixture("style_custom.hwpx")).expect("style_custom opens");
+    doc.parse().expect("style_custom parses");
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("run succeeds");
+    let (style_errors, _) = partition_style_errors(&errors);
+    assert!(
+        style_errors.is_empty(),
+        "permission=true must suppress all Style errors; got {style_errors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// STYLE_PERMISSION constant sanity
+// ---------------------------------------------------------------------------
+
+/// Guard that `STYLE_PERMISSION` is within the Style error range.
+#[test]
+fn style_permission_constant_in_range() {
+    let base = ErrorCode::Style as u32;
+    let next = ErrorCode::Page as u32;
+    assert!(
+        STYLE_PERMISSION >= base,
+        "STYLE_PERMISSION ({STYLE_PERMISSION}) must be >= Style base ({base})"
+    );
+    assert!(
+        STYLE_PERMISSION < next,
+        "STYLE_PERMISSION ({STYLE_PERMISSION}) must be < next category ({next})"
+    );
+}


### PR DESCRIPTION
## Summary

- New `checker::style::check` function validates `Document::run_type_infos` against `StyleSpec.permission`
- When `permission: false`, emits `DvcErrorInfo` with `error_code = STYLE_PERMISSION` (3502) for every run where `is_style == true`
- Wire `style::check` into `Checker::run` with one additive `pub mod style;` declaration and one `errors.extend(...)` call

## Fixtures

| Fixture | Spec | Expected |
|---|---|---|
| `style_default_only.hwpx` | `fixture_spec.json` (`permission: false`) | 0 Style-range errors |
| `style_custom.hwpx` | `fixture_spec.json` (`permission: false`) | >= 1 Style-range error |

## Acceptance checklist

- [x] `checker::style::check` invoked from `Checker::run`
- [x] Emits `DvcErrorInfo` with `error_code` in `ErrorCode::Style` (3500) range (specifically 3502)
- [x] `style_default_only.hwpx` produces zero Style-range errors
- [x] `style_custom.hwpx` produces >= 1 Style-range error with `permission: false`
- [x] 6 integration tests in `tests/check_style.rs`
- [x] 5 unit tests in `checker::style::tests`
- [x] `cargo test --workspace` passes (47 total tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied only to new files

## Files

- NEW: `crates/hwp-dvc-core/src/checker/style/mod.rs`
- EDIT (additive): `crates/hwp-dvc-core/src/checker/mod.rs`
- NEW: `crates/hwp-dvc-core/tests/check_style.rs`