### PR TITLE
feat: implement CheckMacro validator (closes #7)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/macro_/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/macro_/mod.rs
@@ -1,0 +1,36 @@
+//! `CheckMacro` — validates that no macro script is embedded when the
+//! spec prohibits macros.
+//!
+//! Maps to `Checker::CheckMacro` in `references/dvc/Checker.cpp`.
+//! The C++ version calls `OWPMLReader::haveMacroInDocument()` (which
+//! scans `Contents/content.hpf` for `.js` manifest items) and emits
+//! an error when `CMacro::permission` is `false` and a macro is found.
+
+use crate::checker::DvcErrorInfo;
+use crate::document::Document;
+use crate::error::macro_codes;
+use crate::spec::MacroSpec;
+
+/// Run the macro check.
+///
+/// Emits a [`DvcErrorInfo`] with code [`macro_codes::MACRO_PERMISSION`]
+/// (7001) when **both** conditions hold:
+///
+/// 1. `spec.permission == false` — the validation policy forbids macros.
+/// 2. `document.has_macro() == true` — the document contains a `.js`
+///    manifest entry in `Contents/content.hpf`.
+///
+/// Returns an empty `Vec` when either condition is not met (i.e., macros
+/// are permitted, or the document has no macro).
+pub fn check(spec: &MacroSpec, document: &Document) -> Vec<DvcErrorInfo> {
+    if spec.permission || !document.has_macro() {
+        return Vec::new();
+    }
+
+    let error = DvcErrorInfo {
+        error_code: macro_codes::MACRO_PERMISSION,
+        error_string: "macro script found but macro permission is false".to_owned(),
+        ..DvcErrorInfo::default()
+    };
+    vec![error]
+}

--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -5,6 +5,7 @@
 //! method in the C++ version becomes an associated function here.
 
 pub mod hyperlink;
+pub mod macro_;
 pub mod style;
 
 use crate::document::Document;
@@ -78,8 +79,7 @@ impl<'a> Checker<'a> {
     ///
     /// TODO: port `CheckCharShape`, `CheckParaShape`, `CheckTable`,
     /// `CheckSpacialCharacter`, `CheckOutlineShape`, `CheckBullet`,
-    /// `CheckParaNumBullet`, `CheckMacro` from
-    /// `references/dvc/Checker.cpp`.
+    /// `CheckParaNumBullet` from `references/dvc/Checker.cpp`.
     pub fn run(&self) -> DvcResult<Vec<DvcErrorInfo>> {
         let mut errors: Vec<DvcErrorInfo> = Vec::new();
 
@@ -90,6 +90,11 @@ impl<'a> Checker<'a> {
 
         if let Some(style_spec) = &self.spec.style {
             errors.extend(style::check(style_spec, &self.document.run_type_infos));
+        }
+
+        // CheckMacro — emit an error when macros are present but forbidden.
+        if let Some(macro_spec) = &self.spec.macro_ {
+            errors.extend(macro_::check(macro_spec, self.document));
         }
 
         Ok(errors)

--- a/crates/hwp-dvc-core/src/document/mod.rs
+++ b/crates/hwp-dvc-core/src/document/mod.rs
@@ -86,6 +86,42 @@ impl HwpxArchive {
         header::parser::parse_header(&part.bytes)
     }
 
+    /// Return `true` when `Contents/content.hpf` contains an OPF manifest
+    /// item whose `href` attribute includes `.js`.
+    ///
+    /// This replicates `OWPMLReader::haveMacroInDocument` from the C++
+    /// reference. The function does not require `quick-xml` — it scans the
+    /// raw bytes with a lightweight string search, which is sufficient
+    /// because `href` values never use XML character references.
+    pub fn has_macro(&self) -> bool {
+        let part = match self.part("Contents/content.hpf") {
+            Some(p) => p,
+            None => return false,
+        };
+        // The OPF manifest looks like:
+        //   <opf:item id="script" href="Scripts/JScript.js" .../>
+        // We scan for every occurrence of `href="` and check whether the
+        // value before the closing `"` contains `.js`.
+        let text = match std::str::from_utf8(&part.bytes) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let mut search = text;
+        while let Some(pos) = search.find("href=\"") {
+            search = &search[pos + 6..]; // skip past `href="`
+            if let Some(end) = search.find('"') {
+                let href = &search[..end];
+                if href.contains(".js") {
+                    return true;
+                }
+                search = &search[end + 1..];
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
     /// Parse every `Contents/sectionN.xml` part in ascending numeric
     /// order and return one [`Section`] per part.
     ///
@@ -195,6 +231,20 @@ pub struct RunTypeInfo {
 }
 
 impl Document {
+    /// Return `true` when `Contents/content.hpf` lists at least one
+    /// `<opf:item>` whose `href` attribute contains `.js`.
+    ///
+    /// Mirrors `OWPMLReader::haveMacroInDocument` from the reference C++
+    /// source: it scans the OPF manifest for JavaScript items, which
+    /// HWP/HWPX uses to embed macro scripts.
+    ///
+    /// Returns `false` when the archive carries no `Contents/content.hpf`
+    /// part (the manifest is optional in older HWPX variants) or when the
+    /// manifest cannot be parsed.
+    pub fn has_macro(&self) -> bool {
+        self.archive.has_macro()
+    }
+
     pub fn open(path: impl AsRef<Path>) -> DvcResult<Self> {
         let archive = HwpxArchive::open(path)?;
         Ok(Self {

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -62,3 +62,10 @@ pub mod hyperlink_codes {
     /// A run is flagged as a hyperlink but the spec forbids hyperlinks.
     pub const HYPERLINK_PERMISSION: u32 = 6901;
 }
+
+/// Specific error codes in the [`ErrorCode::Macro`] (7000) range.
+pub mod macro_codes {
+    /// Macro script present in the document but `MacroSpec.permission`
+    /// is `false` — the document violates the policy.
+    pub const MACRO_PERMISSION: u32 = 7001;
+}

--- a/crates/hwp-dvc-core/src/spec/mod.rs
+++ b/crates/hwp-dvc-core/src/spec/mod.rs
@@ -31,7 +31,7 @@ pub struct DvcSpec {
     pub style: Option<StyleSpec>,
     #[serde(default)]
     pub hyperlink: Option<HyperlinkSpec>,
-    #[serde(default)]
+    #[serde(rename = "macro", default)]
     pub macro_: Option<MacroSpec>,
 }
 

--- a/crates/hwp-dvc-core/tests/check_macro.rs
+++ b/crates/hwp-dvc-core/tests/check_macro.rs
@@ -1,0 +1,157 @@
+//! Integration tests for the `CheckMacro` validator.
+//!
+//! Global constraint:
+//! - `macro_none.hwpx` + `fixture_spec.json` (permission=false) → 0 Macro errors.
+//! - `macro_present.hwpx` + `fixture_spec.json` (permission=false) → ≥ 1 Macro error.
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::{CheckLevel, Checker, OutputScope};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::error::macro_codes;
+use hwp_dvc_core::spec::DvcSpec;
+
+fn doc_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn spec_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn open_doc(name: &str) -> Document {
+    let mut doc =
+        Document::open(doc_fixture(name)).unwrap_or_else(|e| panic!("failed to open {name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse {name}: {e}"));
+    doc
+}
+
+fn fixture_spec() -> DvcSpec {
+    DvcSpec::from_json_file(spec_fixture("fixture_spec.json"))
+        .expect("fixture_spec.json must parse")
+}
+
+// ---------------------------------------------------------------------------
+// has_macro detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn macro_none_hwpx_has_no_macro() {
+    let doc = open_doc("macro_none.hwpx");
+    assert!(
+        !doc.has_macro(),
+        "macro_none.hwpx must report has_macro() == false"
+    );
+}
+
+#[test]
+fn macro_present_hwpx_has_macro() {
+    let doc = open_doc("macro_present.hwpx");
+    assert!(
+        doc.has_macro(),
+        "macro_present.hwpx must report has_macro() == true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// checker::macro_::check unit behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn macro_check_permission_false_no_macro_emits_no_error() {
+    use hwp_dvc_core::spec::MacroSpec;
+    let doc = open_doc("macro_none.hwpx");
+    let spec = MacroSpec { permission: false };
+    let errors = hwp_dvc_core::checker::macro_::check(&spec, &doc);
+    assert!(
+        errors.is_empty(),
+        "no macro in document → no error even when permission=false"
+    );
+}
+
+#[test]
+fn macro_check_permission_true_with_macro_emits_no_error() {
+    use hwp_dvc_core::spec::MacroSpec;
+    let doc = open_doc("macro_present.hwpx");
+    let spec = MacroSpec { permission: true };
+    let errors = hwp_dvc_core::checker::macro_::check(&spec, &doc);
+    assert!(
+        errors.is_empty(),
+        "macro present but permission=true → no error"
+    );
+}
+
+#[test]
+fn macro_check_permission_false_with_macro_emits_error() {
+    use hwp_dvc_core::spec::MacroSpec;
+    let doc = open_doc("macro_present.hwpx");
+    let spec = MacroSpec { permission: false };
+    let errors = hwp_dvc_core::checker::macro_::check(&spec, &doc);
+    assert_eq!(
+        errors.len(),
+        1,
+        "macro present AND permission=false → exactly one error"
+    );
+    assert_eq!(
+        errors[0].error_code,
+        macro_codes::MACRO_PERMISSION,
+        "error code must be MACRO_PERMISSION (7001)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Checker::run integration (global constraint)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn checker_run_macro_none_emits_zero_macro_errors() {
+    let spec = fixture_spec();
+    let doc = open_doc("macro_none.hwpx");
+    let checker = Checker {
+        spec: &spec,
+        document: &doc,
+        level: CheckLevel::All,
+        scope: OutputScope::default(),
+    };
+    let errors = checker.run().expect("run must succeed");
+    let macro_errors: Vec<_> = errors.iter().filter(|e| e.error_code / 1000 == 7).collect();
+    assert!(
+        macro_errors.is_empty(),
+        "macro_none.hwpx must produce zero Macro-range errors; got: {macro_errors:?}"
+    );
+}
+
+#[test]
+fn checker_run_macro_present_emits_macro_error() {
+    let spec = fixture_spec();
+    // fixture_spec.json has `"macro": { "permission": false }`
+    assert!(
+        spec.macro_.as_ref().map(|m| !m.permission).unwrap_or(false),
+        "fixture_spec must have macro.permission == false for this test to be meaningful"
+    );
+    let doc = open_doc("macro_present.hwpx");
+    let checker = Checker {
+        spec: &spec,
+        document: &doc,
+        level: CheckLevel::All,
+        scope: OutputScope::default(),
+    };
+    let errors = checker.run().expect("run must succeed");
+    let macro_errors: Vec<_> = errors.iter().filter(|e| e.error_code / 1000 == 7).collect();
+    assert!(
+        !macro_errors.is_empty(),
+        "macro_present.hwpx with permission=false must emit ≥1 Macro-range error"
+    );
+    assert_eq!(
+        macro_errors[0].error_code,
+        macro_codes::MACRO_PERMISSION,
+        "Macro-range error code must be MACRO_PERMISSION (7001)"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `Document::has_macro() -> bool` on both `HwpxArchive` and `Document` that scans `Contents/content.hpf` for `<opf:item>` entries whose `href` contains `.js`, replicating `OWPMLReader::haveMacroInDocument`.
- Add `checker::macro_::check(spec, document)` that emits `DvcErrorInfo` with code `7001` (`MACRO_PERMISSION`) when `MacroSpec.permission == false` AND `document.has_macro() == true`.
- Wire `macro_::check` into `Checker::run`.
- Add `macro_codes::MACRO_PERMISSION = 7001` constant under `error.rs`.
- Fix serde rename on `DvcSpec::macro_` field so `"macro"` JSON key deserializes correctly.

## Test plan

- [ ] `macro_none_hwpx_has_no_macro` — `has_macro()` returns false when no `.js` manifest entry.
- [ ] `macro_present_hwpx_has_macro` — `has_macro()` returns true when `Scripts/JScript.js` is listed.
- [ ] `macro_check_permission_false_no_macro_emits_no_error` — no error when doc has no macro even with `permission=false`.
- [ ] `macro_check_permission_true_with_macro_emits_no_error` — no error when `permission=true` even with macro present.
- [ ] `macro_check_permission_false_with_macro_emits_error` — exactly 1 error with code 7001.
- [ ] `checker_run_macro_none_emits_zero_macro_errors` — global constraint: 0 Macro-range errors for `macro_none.hwpx`.
- [ ] `checker_run_macro_present_emits_macro_error` — global constraint: ≥1 Macro-range error for `macro_present.hwpx`.

All 7 new tests + all 36 pre-existing tests pass. Clippy clean.