### PR TITLE
feat: implement CheckTable validator (closes #11)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -10,6 +10,7 @@ pub mod macro_;
 pub mod para_shape;
 pub mod special_character;
 pub mod style;
+pub mod table;
 
 use crate::document::Document;
 use crate::error::DvcResult;
@@ -80,7 +81,7 @@ impl<'a> Checker<'a> {
 
     /// Run every enabled check and return the collected errors.
     ///
-    /// TODO: port `CheckTable`, `CheckOutlineShape`, `CheckBullet`,
+    /// TODO: port `CheckOutlineShape`, `CheckBullet`,
     /// `CheckParaNumBullet` from `references/dvc/Checker.cpp`.
     pub fn run(&self) -> DvcResult<Vec<DvcErrorInfo>> {
         let mut errors: Vec<DvcErrorInfo> = Vec::new();
@@ -123,6 +124,18 @@ impl<'a> Checker<'a> {
         // CheckParaShape — mirrors Checker::CheckParaShape.
         if let Some(parashape_spec) = &self.spec.parashape {
             errors.extend(para_shape::check(self.document, parashape_spec));
+        }
+
+        // CheckTable — mirrors Checker::CheckTable. Scope-gated.
+        if let Some(table_spec) = &self.spec.table {
+            if self.scope.all || self.scope.table || self.scope.table_detail {
+                errors.extend(table::check(
+                    self.document,
+                    table_spec,
+                    self.level,
+                    self.scope,
+                )?);
+            }
         }
 
         Ok(errors)

--- a/crates/hwp-dvc-core/src/checker/table/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/table/mod.rs
@@ -1,0 +1,280 @@
+//! `CheckTable` — validates table borders, treat-as-char, and nested-table
+//! policy against [`TableSpec`].
+//!
+//! Maps to `Checker::CheckTable` / `CheckTableToCheckList` /
+//! `CheckFromBorderInfo` in `references/dvc/Checker.cpp`.
+//!
+//! # Border position encoding
+//!
+//! [`BorderSpec::position`] uses the following integer codes, matching the
+//! reference C++ `JID_BORDER_*` constants (see `JsonModel.h`):
+//! - `1` = left
+//! - `2` = right
+//! - `3` = top
+//! - `4` = bottom
+//!
+//! # Border type encoding
+//!
+//! [`BorderSpec::bordertype`] is an index into the Korean border-name
+//! enumeration from the DVC schema (see `hancom_full.json`):
+//! - `0` = NONE
+//! - `1` = SOLID (실선)
+//! - `2` = DASH  (파선)
+//! - …
+//!
+//! # Color encoding
+//!
+//! [`BorderSpec::color`] is a packed 24-bit RGB integer (0x00RRGGBB).
+//! The document stores the color as an `"#RRGGBB"` hex string.
+//! `color == 0` corresponds to `"#000000"` (black).
+//!
+//! # Cell-level detail mode
+//!
+//! When `OutputScope.table_detail` is `true` the validator should also
+//! inspect each cell's border fill against the spec. That mode is a
+//! **TODO** — this pass implements table-summary mode only, which checks
+//! the outer `borderFillIDRef` of each `<hp:tbl>` element.
+//!
+//! # treatAsChar
+//!
+//! The `treatAsChar` attribute lives in the `<hp:pos>` child of
+//! `<hp:tbl>`. The current `Table` AST node (issue #3) does not expose
+//! this field. Checking `treatAsChar` is therefore a **TODO** pending an
+//! additive field on [`crate::document::section::types::Table`].
+
+use crate::checker::{CheckLevel, DvcErrorInfo, OutputScope};
+use crate::document::header::types::{Border, LineType};
+use crate::document::section::types::Table;
+use crate::document::{Document, HeaderTables};
+use crate::error::DvcResult;
+use crate::spec::BorderSpec;
+use crate::spec::TableSpec;
+
+// ---------------------------------------------------------------------------
+// Error codes (mirrored in error.rs)
+// ---------------------------------------------------------------------------
+
+/// Border line-type mismatch (JID_TABLE_BORDER_TYPE).
+pub const TABLE_BORDER_TYPE: u32 = 3033;
+/// Border width mismatch (JID_TABLE_BORDER_SIZE).
+pub const TABLE_BORDER_SIZE: u32 = 3034;
+/// Border color mismatch (JID_TABLE_BORDER_COLOR).
+pub const TABLE_BORDER_COLOR: u32 = 3035;
+/// treat-as-char mismatch (JID_TABLE_TREATASCHAR).
+pub const TABLE_TREAT_AS_CHAR: u32 = 3004;
+/// Nested table where policy forbids it (JID_TABLE_TABLEINTABLE).
+pub const TABLE_IN_TABLE: u32 = 3056;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run all table checks for the given document against `spec`.
+///
+/// Returns a (possibly empty) vector of [`DvcErrorInfo`] records. The
+/// `level` and `scope` parameters are forwarded from [`crate::checker::Checker`].
+pub fn check(
+    document: &Document,
+    spec: &TableSpec,
+    level: CheckLevel,
+    scope: OutputScope,
+) -> DvcResult<Vec<DvcErrorInfo>> {
+    let _ = scope; // cell-detail mode is a TODO; see module-level doc
+    let header = match &document.header {
+        Some(h) => h,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut errors = Vec::new();
+
+    for section in &document.sections {
+        for table in section.all_tables() {
+            check_table(table, spec, header, level, &mut errors);
+            if level == CheckLevel::Simple && !errors.is_empty() {
+                return Ok(errors);
+            }
+        }
+    }
+
+    Ok(errors)
+}
+
+// ---------------------------------------------------------------------------
+// Per-table validation
+// ---------------------------------------------------------------------------
+
+fn check_table(
+    table: &Table,
+    spec: &TableSpec,
+    header: &HeaderTables,
+    level: CheckLevel,
+    errors: &mut Vec<DvcErrorInfo>,
+) {
+    // --- 1. Border checks ---------------------------------------------------
+    if !spec.border.is_empty() {
+        if let Some(bf) = header.border_fills.get(&table.border_fill_id_ref) {
+            for border_spec in &spec.border {
+                let doc_border = border_by_position(bf, border_spec.position);
+                if let Some(border) = doc_border {
+                    check_border_from_info(table, border, border_spec, level, errors);
+                    if level == CheckLevel::Simple && !errors.is_empty() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    // --- 2. treatAsChar check (TODO) ----------------------------------------
+    // The `Table` AST node does not yet carry `treat_as_char` (from
+    // `<hp:pos treatAsChar=".."/>`). This check is deferred until an additive
+    // field is added to `crate::document::section::types::Table`. Error code
+    // TABLE_TREAT_AS_CHAR (3004) will be emitted once the field is available.
+    let _ = TABLE_TREAT_AS_CHAR; // suppress dead-code lint until TODO is done
+
+    // --- 3. Table-in-table check --------------------------------------------
+    if spec.table_in_table == Some(false) && table.nesting_depth >= 1 {
+        errors.push(DvcErrorInfo {
+            error_code: TABLE_IN_TABLE,
+            table_id: table.id,
+            is_in_table: table.nesting_depth >= 1,
+            is_in_table_in_table: table.nesting_depth >= 2,
+            ..Default::default()
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Border-info sub-check (mirrors CheckFromBorderInfo in Checker.cpp)
+// ---------------------------------------------------------------------------
+
+fn check_border_from_info(
+    table: &Table,
+    doc_border: &Border,
+    spec_border: &BorderSpec,
+    level: CheckLevel,
+    errors: &mut Vec<DvcErrorInfo>,
+) {
+    // Border type check
+    let expected_line_type = border_type_to_line_type(spec_border.bordertype);
+    if doc_border.line_type != expected_line_type {
+        errors.push(DvcErrorInfo {
+            error_code: TABLE_BORDER_TYPE,
+            table_id: table.id,
+            is_in_table: table.nesting_depth >= 1,
+            ..Default::default()
+        });
+        if level == CheckLevel::Simple {
+            return;
+        }
+    }
+
+    // Border size check (tolerance: 0.005 mm)
+    let spec_size = spec_border.size as f32;
+    if (doc_border.width_mm - spec_size).abs() > 0.005 {
+        errors.push(DvcErrorInfo {
+            error_code: TABLE_BORDER_SIZE,
+            table_id: table.id,
+            is_in_table: table.nesting_depth >= 1,
+            ..Default::default()
+        });
+        if level == CheckLevel::Simple {
+            return;
+        }
+    }
+
+    // Border color check
+    let expected_color_str = color_u32_to_hex(spec_border.color);
+    if doc_border.color.to_ascii_uppercase() != expected_color_str {
+        errors.push(DvcErrorInfo {
+            error_code: TABLE_BORDER_COLOR,
+            table_id: table.id,
+            is_in_table: table.nesting_depth >= 1,
+            ..Default::default()
+        });
+        // TABLE_BORDER_COLOR is the last check in this function;
+        // early-return for Simple level is handled by the caller.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return the [`Border`] for position code 1–4 from a `BorderFill`.
+///
+/// Position mapping (from `hancom_full.json` / C++ `JID_BORDER_*`):
+/// - 1 = left, 2 = right, 3 = top, 4 = bottom
+fn border_by_position(bf: &crate::document::header::BorderFill, position: u32) -> Option<&Border> {
+    match position {
+        1 => Some(&bf.left),
+        2 => Some(&bf.right),
+        3 => Some(&bf.top),
+        4 => Some(&bf.bottom),
+        _ => None,
+    }
+}
+
+/// Map a DVC spec `bordertype` integer to a [`LineType`].
+///
+/// Matches the Korean border-name enum in `hancom_full.json`:
+/// 0=없음(NONE), 1=실선(SOLID), 2=파선(DASH), 3=점선(DOT), …
+fn border_type_to_line_type(bordertype: u32) -> LineType {
+    match bordertype {
+        0 => LineType::None,
+        1 => LineType::Solid,
+        2 => LineType::Dash,
+        3 => LineType::Dot,
+        4 => LineType::DashDot,
+        5 => LineType::DashDotDot,
+        6 => LineType::LongDash,
+        7 => LineType::Circle,
+        8 => LineType::DoubleSlim,
+        9 => LineType::SlimThick,
+        10 => LineType::ThickSlim,
+        11 => LineType::SlimThickSlim,
+        12 => LineType::Wave,
+        13 => LineType::DoubleWave,
+        _ => LineType::Other,
+    }
+}
+
+/// Convert a packed 24-bit RGB integer to an uppercase `"#RRGGBB"` string.
+///
+/// `color == 0` → `"#000000"` (black), matching the HWPX XML attribute
+/// format used by [`Border::color`].
+fn color_u32_to_hex(color: u32) -> String {
+    format!("#{:06X}", color & 0x00FF_FFFF)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn border_type_solid_maps_correctly() {
+        assert_eq!(border_type_to_line_type(1), LineType::Solid);
+        assert_eq!(border_type_to_line_type(0), LineType::None);
+        assert_eq!(border_type_to_line_type(2), LineType::Dash);
+    }
+
+    #[test]
+    fn color_u32_to_hex_black() {
+        assert_eq!(color_u32_to_hex(0), "#000000");
+    }
+
+    #[test]
+    fn color_u32_to_hex_red() {
+        assert_eq!(color_u32_to_hex(0x00FF0000), "#FF0000");
+    }
+
+    #[test]
+    fn color_u32_to_hex_masks_high_byte() {
+        // High byte should be ignored
+        assert_eq!(color_u32_to_hex(0xFF000000), "#000000");
+    }
+}

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -26,6 +26,20 @@ pub enum DvcError {
     NotImplemented(&'static str),
 }
 
+/// Individual table error codes (within the `Table = 3000` range).
+///
+/// These mirror the `JID_TABLE_*` constants in `references/dvc/Source/JsonModel.h`.
+/// - `TABLE_BORDER_TYPE`  (3033) — outer border line-type mismatch
+/// - `TABLE_BORDER_SIZE`  (3034) — outer border width mismatch
+/// - `TABLE_BORDER_COLOR` (3035) — outer border color mismatch
+/// - `TABLE_TREAT_AS_CHAR` (3004) — `treatAsChar` attribute mismatch
+/// - `TABLE_IN_TABLE`     (3056) — nested table where policy forbids it
+pub const TABLE_BORDER_TYPE: u32 = 3033;
+pub const TABLE_BORDER_SIZE: u32 = 3034;
+pub const TABLE_BORDER_COLOR: u32 = 3035;
+pub const TABLE_TREAT_AS_CHAR: u32 = 3004;
+pub const TABLE_IN_TABLE: u32 = 3056;
+
 /// Error code ranges mirror the reference C++ implementation
 /// (see `references/dvc/Source/JsonModel.h`).
 ///

--- a/crates/hwp-dvc-core/tests/check_table.rs
+++ b/crates/hwp-dvc-core/tests/check_table.rs
@@ -1,0 +1,173 @@
+//! Integration tests for `checker::table::check`.
+//!
+//! Global constraints (from issue #11):
+//! - `table_simple.hwpx` (pass) → zero 3000-range errors.
+//! - `table_nested.hwpx` (fail) → at least one TABLE_IN_TABLE (3056) error.
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::table::{
+    TABLE_BORDER_COLOR, TABLE_BORDER_SIZE, TABLE_BORDER_TYPE, TABLE_IN_TABLE,
+};
+use hwp_dvc_core::checker::{CheckLevel, Checker, OutputScope};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::spec::DvcSpec;
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn open_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name)).unwrap_or_else(|e| panic!("open {name}: {e}"));
+    doc.parse().unwrap_or_else(|e| panic!("parse {name}: {e}"));
+    doc
+}
+
+fn open_spec(name: &str) -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec(name)).unwrap_or_else(|e| panic!("spec {name}: {e}"))
+}
+
+fn run_table_check(doc: &Document, spec: &DvcSpec) -> Vec<u32> {
+    let checker = Checker {
+        spec,
+        document: doc,
+        level: CheckLevel::All,
+        scope: OutputScope {
+            all: false,
+            table: true,
+            table_detail: false,
+            shape: false,
+            style: false,
+            hyperlink: false,
+        },
+    };
+    checker
+        .run()
+        .expect("checker::run should not fail")
+        .into_iter()
+        .map(|e| e.error_code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// table_simple.hwpx — must produce zero 3000-range errors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_simple_passes_with_fixture_spec() {
+    let doc = open_doc("table_simple.hwpx");
+    let spec = open_spec("fixture_spec.json");
+    let error_codes = run_table_check(&doc, &spec);
+
+    let table_errors: Vec<u32> = error_codes
+        .into_iter()
+        .filter(|&c| (3000..4000).contains(&c))
+        .collect();
+
+    assert!(
+        table_errors.is_empty(),
+        "table_simple.hwpx must produce zero 3000-range errors; got: {table_errors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// table_nested.hwpx — must produce at least one TABLE_IN_TABLE error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_nested_produces_table_in_table_error() {
+    let doc = open_doc("table_nested.hwpx");
+    let spec = open_spec("fixture_spec.json");
+    let error_codes = run_table_check(&doc, &spec);
+
+    assert!(
+        error_codes.contains(&TABLE_IN_TABLE),
+        "table_nested.hwpx must produce TABLE_IN_TABLE (3056); got: {error_codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error-code constant sanity checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_error_codes_have_correct_values() {
+    assert_eq!(TABLE_BORDER_TYPE, 3033);
+    assert_eq!(TABLE_BORDER_SIZE, 3034);
+    assert_eq!(TABLE_BORDER_COLOR, 3035);
+    assert_eq!(TABLE_IN_TABLE, 3056);
+}
+
+// ---------------------------------------------------------------------------
+// Border mismatch detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wrong_bordertype_spec_generates_border_type_error() {
+    let doc = open_doc("table_simple.hwpx");
+    // Use a spec that demands a DASH border (type=2) — the fixture has SOLID.
+    let spec_json = r#"{
+        "table": {
+            "border": [
+                { "position": 1, "bordertype": 2, "size": 0.12, "color": 0 }
+            ]
+        }
+    }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("spec parses");
+    let error_codes = run_table_check(&doc, &spec);
+
+    assert!(
+        error_codes.contains(&TABLE_BORDER_TYPE),
+        "wrong bordertype in spec must produce TABLE_BORDER_TYPE (3033); got: {error_codes:?}"
+    );
+}
+
+#[test]
+fn wrong_border_size_generates_border_size_error() {
+    let doc = open_doc("table_simple.hwpx");
+    // Demand 0.5 mm but the fixture has 0.12 mm.
+    let spec_json = r#"{
+        "table": {
+            "border": [
+                { "position": 1, "bordertype": 1, "size": 0.5, "color": 0 }
+            ]
+        }
+    }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("spec parses");
+    let error_codes = run_table_check(&doc, &spec);
+
+    assert!(
+        error_codes.contains(&TABLE_BORDER_SIZE),
+        "wrong border size must produce TABLE_BORDER_SIZE (3034); got: {error_codes:?}"
+    );
+}
+
+#[test]
+fn wrong_border_color_generates_border_color_error() {
+    let doc = open_doc("table_simple.hwpx");
+    // Demand red (0xFF0000) but the fixture has black (0).
+    let spec_json = r#"{
+        "table": {
+            "border": [
+                { "position": 1, "bordertype": 1, "size": 0.12, "color": 16711680 }
+            ]
+        }
+    }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("spec parses");
+    let error_codes = run_table_check(&doc, &spec);
+
+    assert!(
+        error_codes.contains(&TABLE_BORDER_COLOR),
+        "wrong border color must produce TABLE_BORDER_COLOR (3035); got: {error_codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `crates/hwp-dvc-core/src/checker/table/mod.rs` implementing `checker::table::check`
- Iterate all tables via `Section::all_tables()`, validate outer border fill (positions 1–4: left/right/top/bottom) for type/size/color mismatches
- Emit `TABLE_IN_TABLE (3056)` when `nesting_depth >= 1` and `TableSpec.table_in_table == Some(false)`
- Wire check into `Checker::run` behind `scope.table || scope.table_detail || scope.all` guard
- Append five `TABLE_*` error-code constants (3004, 3033, 3034, 3035, 3056) to `error.rs`
- `treatAsChar` check noted as TODO — `<hp:pos treatAsChar>` attribute is not yet surfaced on the `Table` AST node

## Test plan
- [x] `table_simple.hwpx` + `fixture_spec.json` → zero 3000-range errors
- [x] `table_nested.hwpx` + `fixture_spec.json` → at least one TABLE_IN_TABLE (3056) error
- [x] Wrong bordertype spec → TABLE_BORDER_TYPE (3033)
- [x] Wrong border size spec → TABLE_BORDER_SIZE (3034)
- [x] Wrong border color spec → TABLE_BORDER_COLOR (3035)
- [x] Error-code constant values verified
- [x] `cargo test --workspace` — 46 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean