### PR TITLE
feat: implement CheckOutlineShape validator (closes #12)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -7,6 +7,7 @@
 pub mod char_shape;
 pub mod hyperlink;
 pub mod macro_;
+pub mod outline_shape;
 pub mod para_shape;
 pub mod special_character;
 pub mod style;
@@ -136,6 +137,11 @@ impl<'a> Checker<'a> {
                     self.scope,
                 )?);
             }
+        }
+
+        // CheckOutlineShape — validate outline numbering shapes per level.
+        if let Some(outline_spec) = &self.spec.outlineshape {
+            errors.extend(outline_shape::check(self.document, outline_spec));
         }
 
         Ok(errors)

--- a/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
@@ -1,0 +1,488 @@
+//! `CheckOutlineShape` validator — mirrors `Checker::CheckOutlineShape` and
+//! `CheckOutlineParaHeadToCheckList` / `getLevelType` from the reference C++
+//! implementation (`references/dvc/Checker.cpp`).
+//!
+//! # Logic
+//!
+//! For every paragraph shape in the document that participates in an outline
+//! (i.e. its [`ParaShape::heading_type`] is [`HeadingType::Outline`]), look
+//! up the corresponding [`Numbering`] entry (via
+//! `ParaShape::heading_id_ref`) and the specific level (`heading_level`).
+//! From the [`ParaHead`] at that level, compare:
+//!
+//! - `num_format`      → `LevelType::numbershape` (via ordinal mapping)
+//! - `num_format_text` → `LevelType::numbertype` (template string, when present)
+//!
+//! One [`DvcErrorInfo`] is emitted per (run, mismatched field) pair.
+//!
+//! # Error codes
+//!
+//! | Mismatch              | Code                          |
+//! |-----------------------|-------------------------------|
+//! | `numbertype` template | `OUTLINESHAPE_LEVEL_NUMBERTYPE` (3206) |
+//! | `numbershape` enum    | `OUTLINESHAPE_LEVEL_NUMBERSHAPE` (3207) |
+//!
+//! `OUTLINESHAPE_TYPE` (3201) is reserved for a higher-level shape-name
+//! check (matching the named outline shape template, e.g. "OUTLINE_NAME1")
+//! that the current `OutlineShapeSpec` does not surface — no `type` field
+//! is present in the parsed spec.
+//!
+//! # Deduplication
+//!
+//! Like `CheckParaShape`, the validator deduplicates by `para_pr_id_ref`:
+//! each unique paragraph shape is checked at most once, and the first
+//! matching run in the stream is used as the representative for error
+//! metadata (page, line, char shape, etc.).
+//!
+//! # Gap / TODO
+//!
+//! The `Document` AST does not currently expose `heading_type`,
+//! `heading_id_ref`, or `heading_level` on individual [`RunTypeInfo`]
+//! records. Those fields are on [`ParaShape`] (the header-side shape), which
+//! is reachable via `run.para_pr_id_ref → header.para_shapes`.  This
+//! validator follows the same pattern as `CheckParaShape`: it looks up the
+//! resolved `ParaShape` from the header tables and reads the heading fields
+//! there.  No `RunTypeInfo` changes are required.
+//!
+//! [`ParaShape`]: crate::document::header::ParaShape
+//! [`ParaHead`]: crate::document::header::ParaHead
+//! [`Numbering`]: crate::document::header::Numbering
+//! [`HeadingType`]: crate::document::header::types::enums::HeadingType
+
+use std::collections::HashSet;
+
+use crate::checker::DvcErrorInfo;
+use crate::document::header::types::enums::HeadingType;
+use crate::document::{Document, RunTypeInfo};
+use crate::error::outline_shape_codes::{
+    OUTLINESHAPE_LEVEL_NUMBERSHAPE, OUTLINESHAPE_LEVEL_NUMBERTYPE,
+};
+use crate::spec::OutlineShapeSpec;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Validate outline numbering shapes for every unique outline paragraph in
+/// `document` against `spec`.
+///
+/// Returns an empty `Vec` when:
+/// - the spec has no `leveltype` entries, or
+/// - no paragraph uses outline numbering, or
+/// - all outline paragraphs match the spec.
+#[must_use]
+pub fn check(document: &Document, spec: &OutlineShapeSpec) -> Vec<DvcErrorInfo> {
+    if spec.leveltype.is_empty() {
+        return Vec::new();
+    }
+
+    let header = match document.header.as_ref() {
+        Some(h) => h,
+        None => return Vec::new(),
+    };
+
+    // Deduplicate by `para_pr_id_ref`, keeping the first-seen run as the
+    // representative for error metadata — same pattern as `CheckParaShape`.
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut repr: Vec<&RunTypeInfo> = Vec::new();
+    for run in &document.run_type_infos {
+        if seen.insert(run.para_pr_id_ref) {
+            repr.push(run);
+        }
+    }
+
+    let mut errors: Vec<DvcErrorInfo> = Vec::new();
+
+    for run in repr {
+        let para_shape = match header.para_shapes.get(&run.para_pr_id_ref) {
+            Some(ps) => ps,
+            None => continue,
+        };
+
+        // Only outline paragraphs participate in this check.
+        if para_shape.heading_type != HeadingType::Outline {
+            continue;
+        }
+
+        // For outline headings, the section-level `outlineShapeIDRef` (stored
+        // on each RunTypeInfo as `outline_shape_id_ref`) is the numbering-table
+        // key. The para shape's `heading_id_ref` is 0 for outline paragraphs
+        // that inherit the section-wide outline shape — using it directly would
+        // miss the numbering.  The run carries the correct resolved id.
+        let numbering = match header.numberings.get(&run.outline_shape_id_ref) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // OWPML `<hh:heading level="N"/>` is 0-indexed; `<hh:paraHead level="N"/>`
+        // is 1-indexed. Add 1 to look up the right ParaHead.
+        let para_level = para_shape.heading_level + 1; // 1-indexed level
+        let para_head = match numbering.by_level(para_level) {
+            Some(ph) => ph,
+            None => continue,
+        };
+
+        // Find the spec entry for this level.
+        let spec_entry = match spec.leveltype.iter().find(|lt| lt.level == para_level) {
+            Some(lt) => lt,
+            None => continue,
+        };
+
+        // --- numbertype (template string) ---
+        // Only checked when the spec supplies a `numbertype` value.
+        if let Some(expected_type) = &spec_entry.numbertype {
+            if &para_head.num_format_text != expected_type {
+                errors.push(make_error(run, OUTLINESHAPE_LEVEL_NUMBERTYPE));
+            }
+        }
+
+        // --- numbershape (enum ordinal → num_format string) ---
+        let expected_shape_str = num_shape_ordinal_to_str(spec_entry.numbershape);
+        if para_head.num_format != expected_shape_str {
+            errors.push(make_error(run, OUTLINESHAPE_LEVEL_NUMBERSHAPE));
+        }
+    }
+
+    errors
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map a `numbershape` ordinal (from the DVC JSON spec) to the OWPML
+/// `numFormat` string stored in [`ParaHead::num_format`].
+///
+/// The ordinal enumeration mirrors the C++ `NumShapeType` enum:
+///
+/// ```text
+/// 0  = DIGIT
+/// 1  = CIRCLED_DIGIT
+/// 2  = ROMAN_CAPITAL
+/// 3  = ROMAN_SMALL
+/// 4  = LATIN_CAPITAL
+/// 5  = LATIN_SMALL
+/// 6  = CIRCLED_LATIN_CAPITAL
+/// 7  = CIRCLED_LATIN_SMALL
+/// 8  = HANGUL_SYLLABLE
+/// 9  = CIRCLED_HANGUL_SYLLABLE
+/// 10 = HANGUL_JAMO
+/// 11 = CIRCLED_HANGUL_JAMO
+/// 12 = HANGUL_PHONETIC
+/// 13 = IDEOGRAPH
+/// 14 = CIRCLED_IDEOGRAPH
+/// 15 = DECAGON_CIRCLE
+/// 16 = DECAGON_CIRCLE_HANJA
+/// ```
+///
+/// Unknown ordinals map to `""` so the `!=` comparison that follows will
+/// always fire — treating an unknown spec value as a definite mismatch is
+/// the safe / conservative choice.
+fn num_shape_ordinal_to_str(ordinal: u32) -> &'static str {
+    match ordinal {
+        0 => "DIGIT",
+        1 => "CIRCLED_DIGIT",
+        2 => "ROMAN_CAPITAL",
+        3 => "ROMAN_SMALL",
+        4 => "LATIN_CAPITAL",
+        5 => "LATIN_SMALL",
+        6 => "CIRCLED_LATIN_CAPITAL",
+        7 => "CIRCLED_LATIN_SMALL",
+        8 => "HANGUL_SYLLABLE",
+        9 => "CIRCLED_HANGUL_SYLLABLE",
+        10 => "HANGUL_JAMO",
+        11 => "CIRCLED_HANGUL_JAMO",
+        12 => "HANGUL_PHONETIC",
+        13 => "IDEOGRAPH",
+        14 => "CIRCLED_IDEOGRAPH",
+        15 => "DECAGON_CIRCLE",
+        16 => "DECAGON_CIRCLE_HANJA",
+        _ => "",
+    }
+}
+
+/// Build a [`DvcErrorInfo`] from a representative run and an error code.
+fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
+    DvcErrorInfo {
+        para_pr_id_ref: run.para_pr_id_ref,
+        char_pr_id_ref: run.char_pr_id_ref,
+        text: run.text.clone(),
+        page_no: run.page_no,
+        line_no: run.line_no,
+        error_code,
+        table_id: run.table_id,
+        is_in_table: run.is_in_table,
+        is_in_table_in_table: run.is_in_table_in_table,
+        table_row: run.table_row,
+        table_col: run.table_col,
+        is_in_shape: run.is_in_shape,
+        use_hyperlink: run.is_hyperlink,
+        use_style: run.is_style,
+        error_string: String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::header::types::enums::HeadingType;
+    use crate::document::header::types::shapes::{Numbering, ParaHead, ParaShape};
+    use crate::document::header::HeaderTables;
+    use crate::document::{Document, RunTypeInfo};
+    use crate::error::outline_shape_codes::{
+        OUTLINESHAPE_LEVEL_NUMBERSHAPE, OUTLINESHAPE_LEVEL_NUMBERTYPE,
+    };
+    use crate::spec::{LevelType, OutlineShapeSpec};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal [`Document`] with one run referencing a given
+    /// paragraph shape. The paragraph shape has the supplied heading type,
+    /// heading level. The `outline_shape_id_ref` on the run is set to
+    /// `numbering_id` to mirror the section-level `outlineShapeIDRef`
+    /// path used by the validator.
+    fn doc_with_outline_para(
+        para_id: u32,
+        numbering_id: u32,
+        heading_level: u32, // 0-indexed (heading_level=0 → level 1)
+        numbering: Numbering,
+    ) -> Document {
+        let mut header = HeaderTables::default();
+
+        let ps = ParaShape {
+            id: para_id,
+            heading_type: HeadingType::Outline,
+            heading_id_ref: 0, // always 0 for section-wide outline shapes
+            heading_level,
+            ..Default::default()
+        };
+        header.para_shapes.insert(para_id, ps);
+        header.numberings.insert(numbering_id, numbering);
+
+        let run = RunTypeInfo {
+            para_pr_id_ref: para_id,
+            // The section's outlineShapeIDRef maps to the numbering id.
+            outline_shape_id_ref: numbering_id,
+            ..Default::default()
+        };
+
+        Document {
+            header: Some(header),
+            run_type_infos: vec![run],
+            ..Default::default()
+        }
+    }
+
+    /// Build a one-level [`Numbering`] with the given `num_format` and
+    /// `num_format_text` at level 1.
+    fn one_level_numbering(id: u32, num_format: &str, num_format_text: &str) -> Numbering {
+        Numbering {
+            id,
+            start: 0,
+            para_heads: vec![ParaHead {
+                level: 1,
+                num_format: num_format.into(),
+                num_format_text: num_format_text.into(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// A spec with a single `LevelType` entry at level 1.
+    fn spec_for_level1(numbertype: Option<&str>, numbershape: u32) -> OutlineShapeSpec {
+        OutlineShapeSpec {
+            leveltype: vec![LevelType {
+                level: 1,
+                numbertype: numbertype.map(str::to_string),
+                numbershape,
+            }],
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Passing cases
+    // -----------------------------------------------------------------------
+
+    /// When the document's outline level 1 matches the spec exactly, no errors.
+    #[test]
+    fn matching_numbershape_and_numbertype_produces_no_errors() {
+        // level 1: DIGIT ("^1.")  → spec ordinal 0, numbertype "^1."
+        let num = one_level_numbering(1, "DIGIT", "^1.");
+        let doc = doc_with_outline_para(0, 1, 0, num);
+        let spec = spec_for_level1(Some("^1."), 0);
+        let errors = check(&doc, &spec);
+        assert!(
+            errors.is_empty(),
+            "matching outline spec must produce no errors; got {errors:?}"
+        );
+    }
+
+    /// When `numbertype` is absent from the spec, only `numbershape` is checked.
+    #[test]
+    fn absent_numbertype_skips_template_check() {
+        let num = one_level_numbering(1, "DIGIT", "^1.");
+        let doc = doc_with_outline_para(0, 1, 0, num);
+        let spec = spec_for_level1(None, 0); // no numbertype in spec
+        let errors = check(&doc, &spec);
+        assert!(
+            errors.is_empty(),
+            "absent numbertype must not produce NUMBERTYPE errors; got {errors:?}"
+        );
+    }
+
+    /// Non-outline paragraphs (HeadingType::None) are silently ignored.
+    #[test]
+    fn non_outline_paragraphs_are_skipped() {
+        let mut header = HeaderTables::default();
+        let ps = ParaShape {
+            id: 5,
+            heading_type: HeadingType::None, // not an outline paragraph
+            ..Default::default()
+        };
+        header.para_shapes.insert(5, ps);
+
+        let run = RunTypeInfo {
+            para_pr_id_ref: 5,
+            ..Default::default()
+        };
+
+        let doc = Document {
+            header: Some(header),
+            run_type_infos: vec![run],
+            ..Default::default()
+        };
+
+        let spec = spec_for_level1(Some("^1."), 0);
+        let errors = check(&doc, &spec);
+        assert!(
+            errors.is_empty(),
+            "non-outline paragraphs must not produce errors; got {errors:?}"
+        );
+    }
+
+    /// An empty `leveltype` in the spec means the check is a no-op.
+    #[test]
+    fn empty_spec_produces_no_errors() {
+        let num = one_level_numbering(1, "HANGUL_SYLLABLE", "^2.");
+        let doc = doc_with_outline_para(0, 1, 1, num);
+        let spec = OutlineShapeSpec { leveltype: vec![] };
+        let errors = check(&doc, &spec);
+        assert!(errors.is_empty(), "empty spec must produce no errors");
+    }
+
+    // -----------------------------------------------------------------------
+    // Failing cases
+    // -----------------------------------------------------------------------
+
+    /// `numbershape` mismatch fires `OUTLINESHAPE_LEVEL_NUMBERSHAPE`.
+    ///
+    /// **Synthetic fail case**: document has `HANGUL_SYLLABLE` (ordinal 8)
+    /// at level 1, but the spec requires ordinal 0 (`DIGIT`).
+    #[test]
+    fn numbershape_mismatch_fires_error() {
+        // Document: level 1, HANGUL_SYLLABLE
+        let num = one_level_numbering(1, "HANGUL_SYLLABLE", "^1.");
+        let doc = doc_with_outline_para(0, 1, 0, num);
+        // Spec: level 1, expects DIGIT (ordinal 0)
+        let spec = spec_for_level1(None, 0);
+        let errors = check(&doc, &spec);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.error_code == OUTLINESHAPE_LEVEL_NUMBERSHAPE),
+            "HANGUL_SYLLABLE vs DIGIT must fire OUTLINESHAPE_LEVEL_NUMBERSHAPE; got {errors:?}"
+        );
+    }
+
+    /// `numbertype` mismatch fires `OUTLINESHAPE_LEVEL_NUMBERTYPE`.
+    ///
+    /// **Synthetic fail case**: document template is `"^1)"` but spec expects `"^1."`.
+    #[test]
+    fn numbertype_mismatch_fires_error() {
+        let num = one_level_numbering(1, "DIGIT", "^1)"); // wrong suffix
+        let doc = doc_with_outline_para(0, 1, 0, num);
+        let spec = spec_for_level1(Some("^1."), 0); // expects "^1."
+        let errors = check(&doc, &spec);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.error_code == OUTLINESHAPE_LEVEL_NUMBERTYPE),
+            "wrong numbertype must fire OUTLINESHAPE_LEVEL_NUMBERTYPE; got {errors:?}"
+        );
+    }
+
+    /// Duplicate `para_pr_id_ref`s produce at most one error per shape
+    /// (deduplication by para shape id).
+    #[test]
+    fn duplicate_para_ids_produce_one_error() {
+        let mut header = HeaderTables::default();
+
+        let ps = ParaShape {
+            id: 3,
+            heading_type: HeadingType::Outline,
+            heading_id_ref: 0, // section-wide; actual numbering key is on run
+            heading_level: 0,
+            ..Default::default()
+        };
+        header.para_shapes.insert(3, ps);
+        header.numberings.insert(
+            1,
+            Numbering {
+                id: 1,
+                start: 0,
+                para_heads: vec![ParaHead {
+                    level: 1,
+                    num_format: "HANGUL_SYLLABLE".into(), // wrong
+                    num_format_text: "^1.".into(),
+                    ..Default::default()
+                }],
+            },
+        );
+
+        // Three runs all referencing the same para shape.
+        let make_run = || RunTypeInfo {
+            para_pr_id_ref: 3,
+            outline_shape_id_ref: 1, // section outline shape → numbering id 1
+            ..Default::default()
+        };
+
+        let doc = Document {
+            header: Some(header),
+            run_type_infos: vec![make_run(), make_run(), make_run()],
+            ..Default::default()
+        };
+
+        let spec = spec_for_level1(None, 0); // expects DIGIT
+        let errors = check(&doc, &spec);
+        let shape_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.error_code == OUTLINESHAPE_LEVEL_NUMBERSHAPE)
+            .collect();
+        assert_eq!(
+            shape_errors.len(),
+            1,
+            "three runs with the same para_pr_id_ref must produce exactly one NUMBERSHAPE error"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // num_shape_ordinal_to_str
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ordinal_mapping_spot_checks() {
+        assert_eq!(num_shape_ordinal_to_str(0), "DIGIT");
+        assert_eq!(num_shape_ordinal_to_str(1), "CIRCLED_DIGIT");
+        assert_eq!(num_shape_ordinal_to_str(8), "HANGUL_SYLLABLE");
+        assert_eq!(num_shape_ordinal_to_str(9), "CIRCLED_HANGUL_SYLLABLE");
+        assert_eq!(num_shape_ordinal_to_str(10), "HANGUL_JAMO");
+        assert_eq!(num_shape_ordinal_to_str(16), "DECAGON_CIRCLE_HANJA");
+        assert_eq!(num_shape_ordinal_to_str(99), ""); // unknown → empty
+    }
+}

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -105,6 +105,18 @@ pub const CHARSHAPE_RATIO: u32 = 1007;
 /// Spacing value outside the allowed range (`JID_CHAR_SHAPE_SPACING = JID_CHAR_SHAPE + 8`).
 pub const CHARSHAPE_SPACING: u32 = 1008;
 
+/// Outline-shape error codes within the [`ErrorCode::OutlineShape`] (3200) range.
+///
+/// These mirror `JID_OUTLINESHAPE_*` constants from `references/dvc/Source/JsonModel.h`.
+pub mod outline_shape_codes {
+    /// `JID_OUTLINESHAPE_TYPE` (3201) — outline shape type mismatch.
+    pub const OUTLINESHAPE_TYPE: u32 = 3201;
+    /// `JID_OUTLINESHAPE_LEVELTYPE_NUMBERTYPE` (3206) — level numbertype template mismatch.
+    pub const OUTLINESHAPE_LEVEL_NUMBERTYPE: u32 = 3206;
+    /// `JID_OUTLINESHAPE_LEVELTYPE_NUMBERSHAPE` (3207) — level numbershape enum mismatch.
+    pub const OUTLINESHAPE_LEVEL_NUMBERSHAPE: u32 = 3207;
+}
+
 /// Individual paragraph-shape error codes (2000-range).
 ///
 /// These map to `JID_PARA_SHAPE_*` constants in the reference C++

--- a/crates/hwp-dvc-core/tests/check_outline_shape.rs
+++ b/crates/hwp-dvc-core/tests/check_outline_shape.rs
@@ -1,0 +1,219 @@
+//! Integration tests for the `CheckOutlineShape` validator.
+//!
+//! Each test follows the full pipeline:
+//!   `Document::open` → `Document::parse` → `Checker::new` → `Checker::run`
+//!
+//! # Fixtures used
+//!
+//! | Fixture                   | Spec                    | Expected outcome                             |
+//! |---------------------------|-------------------------|----------------------------------------------|
+//! | `outline_multilevel.hwpx` | `hancom_test.json`      | zero OutlineShape-range (3200+) errors       |
+//! | `outline_multilevel.hwpx` | inline wrong spec       | ≥ 1 OUTLINESHAPE_LEVEL_NUMBERSHAPE error     |
+//!
+//! The `outline_multilevel.hwpx` fixture has levels 1–10 whose `numFormat`
+//! and template text match exactly the entries in `hancom_test.json`.
+//! The "wrong spec" sub-test mutates one level's `numbershape` to a value
+//! that diverges from the document — that is a **synthetic fail case**
+//! authored directly in this test rather than a separate fixture file.
+//!
+//! # Global constraint
+//!
+//! Per the issue orchestrator's constraint, `outline_multilevel.hwpx`
+//! must produce **zero** errors in the 3200-range (OutlineShape) when
+//! checked against `hancom_test.json`.
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::{Checker, DvcErrorInfo};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::error::outline_shape_codes::{
+    OUTLINESHAPE_LEVEL_NUMBERSHAPE, OUTLINESHAPE_LEVEL_NUMBERTYPE,
+};
+use hwp_dvc_core::error::ErrorCode;
+use hwp_dvc_core::spec::DvcSpec;
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+fn doc_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn spec_fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+/// Load and run the full checker pipeline. Returns all errors.
+fn run_check(doc_name: &str, spec_name: &str) -> Vec<DvcErrorInfo> {
+    let spec = DvcSpec::from_json_file(spec_fixture(spec_name))
+        .unwrap_or_else(|e| panic!("failed to parse spec {spec_name}: {e}"));
+
+    let mut doc = Document::open(doc_fixture(doc_name))
+        .unwrap_or_else(|e| panic!("failed to open {doc_name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse {doc_name}: {e}"));
+
+    Checker::new(&spec, &doc)
+        .run()
+        .unwrap_or_else(|e| panic!("Checker::run failed for {doc_name}: {e}"))
+}
+
+/// Partition errors into OutlineShape-range (3200–3299) and other.
+fn partition_outline_errors(errors: &[DvcErrorInfo]) -> (Vec<&DvcErrorInfo>, Vec<&DvcErrorInfo>) {
+    let base = ErrorCode::OutlineShape as u32;
+    let next = ErrorCode::Bullet as u32;
+    errors
+        .iter()
+        .partition(|e| e.error_code >= base && e.error_code < next)
+}
+
+// ---------------------------------------------------------------------------
+// Pass case: outline_multilevel + hancom_test.json → zero 3200-range errors
+// ---------------------------------------------------------------------------
+
+/// The multilevel outline fixture must produce zero OutlineShape-range errors
+/// when validated against `hancom_test.json` — the spec perfectly matches the
+/// fixture's outline layout (levels 1–10, numFormat+template for each).
+#[test]
+fn outline_multilevel_passes_hancom_test_spec() {
+    let errors = run_check("outline_multilevel.hwpx", "hancom_test.json");
+    let (outline_errors, _) = partition_outline_errors(&errors);
+    assert!(
+        outline_errors.is_empty(),
+        "outline_multilevel.hwpx must produce zero OutlineShape errors against hancom_test.json; \
+         got {outline_errors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail case: inline wrong spec → fires OUTLINESHAPE_LEVEL_NUMBERSHAPE
+//
+// Synthetic fail case: we use the same fixture but replace level 1's
+// `numbershape` with 8 (HANGUL_SYLLABLE). The fixture's level 1 is DIGIT
+// (ordinal 0), so this must produce an OUTLINESHAPE_LEVEL_NUMBERSHAPE error.
+// ---------------------------------------------------------------------------
+
+/// When the spec demands a different `numbershape` for level 1, the validator
+/// must emit at least one `OUTLINESHAPE_LEVEL_NUMBERSHAPE` error.
+///
+/// **Synthetic fail case**: the fixture has level 1 = DIGIT (ordinal 0), but
+/// the inline spec specifies ordinal 8 (HANGUL_SYLLABLE).
+#[test]
+fn wrong_numbershape_for_level1_fires_error() {
+    // Build a spec where level 1 has the wrong numbershape (8 = HANGUL_SYLLABLE
+    // instead of 0 = DIGIT).
+    let spec_json = r#"{
+        "outlineshape": {
+            "leveltype": [
+                { "level": 1, "numbershape": 8 }
+            ]
+        }
+    }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("inline spec parses");
+
+    let mut doc =
+        Document::open(doc_fixture("outline_multilevel.hwpx")).expect("outline_multilevel opens");
+    doc.parse().expect("outline_multilevel parses");
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("run succeeds");
+
+    let (outline_errors, _) = partition_outline_errors(&errors);
+    assert!(
+        outline_errors
+            .iter()
+            .any(|e| e.error_code == OUTLINESHAPE_LEVEL_NUMBERSHAPE),
+        "wrong numbershape for level 1 must fire OUTLINESHAPE_LEVEL_NUMBERSHAPE; \
+         got {outline_errors:?}"
+    );
+}
+
+/// When the spec demands a different `numbertype` template for level 2, the
+/// validator must emit at least one `OUTLINESHAPE_LEVEL_NUMBERTYPE` error.
+///
+/// **Synthetic fail case**: the fixture level 2 template is `"^2."` but the
+/// spec specifies `"^2)"`.
+#[test]
+fn wrong_numbertype_for_level2_fires_error() {
+    let spec_json = r#"{
+        "outlineshape": {
+            "leveltype": [
+                { "level": 2, "numbertype": "^2)", "numbershape": 8 }
+            ]
+        }
+    }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("inline spec parses");
+
+    let mut doc =
+        Document::open(doc_fixture("outline_multilevel.hwpx")).expect("outline_multilevel opens");
+    doc.parse().expect("outline_multilevel parses");
+
+    let errors = Checker::new(&spec, &doc).run().expect("run succeeds");
+
+    let (outline_errors, _) = partition_outline_errors(&errors);
+    assert!(
+        outline_errors
+            .iter()
+            .any(|e| e.error_code == OUTLINESHAPE_LEVEL_NUMBERTYPE),
+        "wrong numbertype for level 2 must fire OUTLINESHAPE_LEVEL_NUMBERTYPE; \
+         got {outline_errors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// No-spec guard: missing outlineshape key → zero outline errors
+// ---------------------------------------------------------------------------
+
+/// When the spec has no `outlineshape` key at all, the outline checker must
+/// be a no-op — zero OutlineShape-range errors regardless of the document.
+#[test]
+fn no_outlineshape_spec_produces_zero_outline_errors() {
+    let errors = run_check("outline_multilevel.hwpx", "fixture_spec.json");
+    let (outline_errors, _) = partition_outline_errors(&errors);
+    assert!(
+        outline_errors.is_empty(),
+        "fixture_spec.json has no outlineshape key; must produce zero outline errors; \
+         got {outline_errors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error code range sanity checks
+// ---------------------------------------------------------------------------
+
+/// `OUTLINESHAPE_LEVEL_NUMBERTYPE` must be in the OutlineShape range [3200, 3300).
+#[test]
+fn outlineshape_level_numbertype_constant_in_range() {
+    let base = ErrorCode::OutlineShape as u32;
+    let next = ErrorCode::Bullet as u32;
+    assert!(
+        OUTLINESHAPE_LEVEL_NUMBERTYPE >= base,
+        "OUTLINESHAPE_LEVEL_NUMBERTYPE ({OUTLINESHAPE_LEVEL_NUMBERTYPE}) must be >= {base}"
+    );
+    assert!(
+        OUTLINESHAPE_LEVEL_NUMBERTYPE < next,
+        "OUTLINESHAPE_LEVEL_NUMBERTYPE ({OUTLINESHAPE_LEVEL_NUMBERTYPE}) must be < {next}"
+    );
+}
+
+/// `OUTLINESHAPE_LEVEL_NUMBERSHAPE` must be in the OutlineShape range [3200, 3300).
+#[test]
+fn outlineshape_level_numbershape_constant_in_range() {
+    let base = ErrorCode::OutlineShape as u32;
+    let next = ErrorCode::Bullet as u32;
+    assert!(
+        OUTLINESHAPE_LEVEL_NUMBERSHAPE >= base,
+        "OUTLINESHAPE_LEVEL_NUMBERSHAPE ({OUTLINESHAPE_LEVEL_NUMBERSHAPE}) must be >= {base}"
+    );
+    assert!(
+        OUTLINESHAPE_LEVEL_NUMBERSHAPE < next,
+        "OUTLINESHAPE_LEVEL_NUMBERSHAPE ({OUTLINESHAPE_LEVEL_NUMBERSHAPE}) must be < {next}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `crates/hwp-dvc-core/src/checker/outline_shape/mod.rs` with `check()` function that validates outline numbering per level
- Append `OUTLINESHAPE_LEVEL_NUMBERTYPE` (3206) and `OUTLINESHAPE_LEVEL_NUMBERSHAPE` (3207) to `error.rs`
- Wire `outline_shape::check` into `Checker::run` (additive, after CheckTable)
- Add `tests/check_outline_shape.rs` with 6 integration tests covering pass/fail/no-spec cases

## Design notes

The validator resolves the numbering table via `run.outline_shape_id_ref` (the section-level `outlineShapeIDRef`) rather than `para_shape.heading_id_ref` (which is 0 for section-wide outline shapes in HWPX). This matches the fixture: `outline_multilevel.hwpx` sets `outlineShapeIDRef=1` at the section level while outline paragraphs carry `heading idRef="0"`.

`numbershape` ordinals are mapped to OWPML `numFormat` strings via `num_shape_ordinal_to_str` (0=DIGIT through 16=DECAGON_CIRCLE_HANJA), mirroring the C++ `NumShapeType` enum.

## Test plan

- [x] `outline_multilevel.hwpx` + `hancom_test.json` → zero 3200-range errors (global constraint)
- [x] Synthetic fail: level 1 `numbershape=8` vs fixture's DIGIT → fires `OUTLINESHAPE_LEVEL_NUMBERSHAPE`
- [x] Synthetic fail: level 2 `numbertype="^2)"` vs fixture's `"^2."` → fires `OUTLINESHAPE_LEVEL_NUMBERTYPE`
- [x] No `outlineshape` spec key → zero outline errors
- [x] Error code range guards for 3206 and 3207
- [x] `cargo test --workspace` passes (77 unit + 6 integration outline tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean