### PR TITLE
feat: add XML output formatter (closes #15)

### DIFF
--- a/crates/hwp-dvc-cli/Cargo.toml
+++ b/crates/hwp-dvc-cli/Cargo.toml
@@ -13,6 +13,10 @@ readme.workspace = true
 name = "hwp-dvc"
 path = "src/main.rs"
 
+[features]
+## Enable the XML output formatter. Forwards to `hwp-dvc-core/xml`.
+xml = ["hwp-dvc-core/xml"]
+
 [dependencies]
 hwp-dvc-core = { path = "../hwp-dvc-core" }
 anyhow.workspace = true

--- a/crates/hwp-dvc-cli/src/main.rs
+++ b/crates/hwp-dvc-cli/src/main.rs
@@ -79,7 +79,8 @@ struct Cli {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum Format {
     Json,
-    // Xml, // not yet implemented
+    #[cfg(feature = "xml")]
+    Xml,
 }
 
 fn main() -> Result<()> {
@@ -118,6 +119,8 @@ fn main() -> Result<()> {
 
     let rendered = match cli.format {
         Format::Json => output::to_json(&errors, cli.pretty)?,
+        #[cfg(feature = "xml")]
+        Format::Xml => output::to_xml(&errors, cli.pretty)?,
     };
 
     if let Some(path) = cli.file.as_ref() {

--- a/crates/hwp-dvc-core/Cargo.toml
+++ b/crates/hwp-dvc-core/Cargo.toml
@@ -21,5 +21,9 @@ zip.workspace = true
 quick-xml.workspace = true
 tracing.workspace = true
 
+[features]
+## Enable the XML output formatter (`output::to_xml`, `output::Format::Xml`).
+xml = []
+
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/hwp-dvc-core/src/output/mod.rs
+++ b/crates/hwp-dvc-core/src/output/mod.rs
@@ -1,21 +1,36 @@
 //! Output formatters for validation results.
 //!
-//! Maps to `IDVCOutput` / `DVCOutputJson` in the reference. Only JSON
-//! is implemented initially; XML and plain text can be added behind
-//! the same [`Format`] enum.
+//! Maps to `IDVCOutput` / `DVCOutputJson` in the reference. JSON is the
+//! default; XML is available when the `xml` Cargo feature is enabled.
+//!
+//! # Feature flags
+//!
+//! | Feature | Effect |
+//! |---------|--------|
+//! | *(none)* | JSON only (`Format::Json`, `to_json`) |
+//! | `xml` | Adds `Format::Xml` and `to_xml` |
+
+#[cfg(feature = "xml")]
+mod xml;
 
 use serde::Serialize;
 
 use crate::checker::DvcErrorInfo;
 use crate::error::DvcResult;
 
+/// Selects the serialization format for validation results.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Format {
     #[default]
     Json,
-    // Xml,   // TODO
-    // Text,  // TODO
+    /// XML output — only available when the `xml` feature is compiled in.
+    #[cfg(feature = "xml")]
+    Xml,
 }
+
+#[cfg(feature = "xml")]
+pub use xml::to_xml;
 
 #[derive(Debug, Serialize)]
 struct JsonRecord<'a> {

--- a/crates/hwp-dvc-core/src/output/xml.rs
+++ b/crates/hwp-dvc-core/src/output/xml.rs
@@ -1,0 +1,102 @@
+//! XML output formatter.
+//!
+//! Produces a `<dvcErrors>` document containing one `<error>` element per
+//! [`DvcErrorInfo`] record. Field names mirror the JSON keys defined in the
+//! companion `json.rs` module so that both outputs are structurally equivalent.
+//!
+//! # Schema (informal)
+//!
+//! ```xml
+//! <dvcErrors>
+//!   <error>
+//!     <charIDRef>0</charIDRef>
+//!     <paraPrIDRef>0</paraPrIDRef>
+//!     <text>example run text</text>
+//!     <pageNo>1</pageNo>
+//!     <lineNo>0</lineNo>
+//!     <errorCode>1004</errorCode>
+//!     <tableID>0</tableID>
+//!     <isInTable>false</isInTable>
+//!     <isInTableInTable>false</isInTableInTable>
+//!     <tableRow>0</tableRow>
+//!     <tableCol>0</tableCol>
+//!   </error>
+//! </dvcErrors>
+//! ```
+//!
+//! This module is compiled only when the `xml` Cargo feature is enabled.
+
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::Writer;
+
+use crate::checker::DvcErrorInfo;
+use crate::error::DvcResult;
+
+/// Serialize `errors` as an XML string.
+///
+/// When `pretty` is `true` the output is indented with two spaces; when
+/// `false` the entire document is written on a single line (no whitespace
+/// between tags).
+pub fn to_xml(errors: &[DvcErrorInfo], pretty: bool) -> DvcResult<String> {
+    let mut buf: Vec<u8> = Vec::new();
+
+    let mut writer = if pretty {
+        Writer::new_with_indent(&mut buf, b' ', 2)
+    } else {
+        Writer::new(&mut buf)
+    };
+
+    // <?xml version="1.0" encoding="UTF-8"?>
+    writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+
+    // <dvcErrors>
+    writer.write_event(Event::Start(BytesStart::new("dvcErrors")))?;
+
+    for error in errors {
+        write_error(&mut writer, error)?;
+    }
+
+    // </dvcErrors>
+    writer.write_event(Event::End(BytesEnd::new("dvcErrors")))?;
+
+    let s = String::from_utf8(buf)
+        .map_err(|e| quick_xml::Error::Io(std::sync::Arc::new(std::io::Error::other(e))))?;
+    Ok(s)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+type XmlWriter<'a> = Writer<&'a mut Vec<u8>>;
+
+fn write_error(w: &mut XmlWriter<'_>, e: &DvcErrorInfo) -> Result<(), quick_xml::Error> {
+    w.write_event(Event::Start(BytesStart::new("error")))?;
+
+    write_elem(w, "charIDRef", &e.char_pr_id_ref.to_string())?;
+    write_elem(w, "paraPrIDRef", &e.para_pr_id_ref.to_string())?;
+    write_elem(w, "text", &e.text)?;
+    write_elem(w, "pageNo", &e.page_no.to_string())?;
+    write_elem(w, "lineNo", &e.line_no.to_string())?;
+    write_elem(w, "errorCode", &e.error_code.to_string())?;
+    write_elem(w, "tableID", &e.table_id.to_string())?;
+    write_elem(w, "isInTable", bool_str(e.is_in_table))?;
+    write_elem(w, "isInTableInTable", bool_str(e.is_in_table_in_table))?;
+    write_elem(w, "tableRow", &e.table_row.to_string())?;
+    write_elem(w, "tableCol", &e.table_col.to_string())?;
+
+    w.write_event(Event::End(BytesEnd::new("error")))?;
+    Ok(())
+}
+
+fn write_elem(w: &mut XmlWriter<'_>, tag: &str, value: &str) -> Result<(), quick_xml::Error> {
+    w.write_event(Event::Start(BytesStart::new(tag)))?;
+    w.write_event(Event::Text(BytesText::new(value)))?;
+    w.write_event(Event::End(BytesEnd::new(tag)))?;
+    Ok(())
+}
+
+#[inline]
+const fn bool_str(v: bool) -> &'static str {
+    if v { "true" } else { "false" }
+}

--- a/crates/hwp-dvc-core/tests/xml_output.rs
+++ b/crates/hwp-dvc-core/tests/xml_output.rs
@@ -1,0 +1,179 @@
+//! Integration tests for the XML output formatter.
+//!
+//! These tests are compiled and run only when the `xml` Cargo feature is
+//! enabled:
+//!
+//! ```text
+//! cargo test --workspace --features xml
+//! ```
+//!
+//! # Coverage
+//!
+//! * `charshape_fail_font.hwpx` against `fixture_spec.json` — produces at
+//!   least one `CHARSHAPE_FONT` (1004) error. The serialised XML must contain
+//!   `<errorCode>1004</errorCode>` and a non-empty `<text>` element.
+//!
+//! * Pretty-print round-trip: the pretty output is a super-string of the
+//!   compact output (all content is present, just with added whitespace).
+//!
+//! * Empty input: `to_xml(&[], …)` must produce a valid, well-formed XML
+//!   document with an empty `<dvcErrors/>` root (or `<dvcErrors></dvcErrors>`).
+
+#![cfg(feature = "xml")]
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::Checker;
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::output::to_xml;
+use hwp_dvc_core::spec::DvcSpec;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fixture helpers (mirrors the pattern used in check_char_shape.rs)
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn load_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture {name}: {e}"));
+    doc
+}
+
+fn load_spec(name: &str) -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec_path(name))
+        .unwrap_or_else(|e| panic!("failed to load spec {name}: {e}"))
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Real-fixture integration test (global constraint)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Load `charshape_fail_font.hwpx`, run the checker against `fixture_spec.json`,
+/// serialise the result as XML, and assert that the output contains the expected
+/// element tags and the CHARSHAPE_FONT error code.
+#[test]
+fn xml_output_contains_charshape_font_error() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("Checker::run must not fail");
+
+    // Confirm the checker produced at least one 1004 error so the XML
+    // assertion below is meaningful.
+    let font_errors: Vec<_> = errors.iter().filter(|e| e.error_code == 1004).collect();
+    assert!(
+        !font_errors.is_empty(),
+        "charshape_fail_font.hwpx must produce CHARSHAPE_FONT (1004) errors; got none. \
+         All errors: {errors:?}",
+    );
+
+    let xml = to_xml(&errors, false).expect("to_xml must not fail");
+
+    // Must have a valid XML declaration.
+    assert!(
+        xml.starts_with("<?xml"),
+        "XML output must start with XML declaration; got: {xml:.80}"
+    );
+
+    // Root element.
+    assert!(
+        xml.contains("<dvcErrors>"),
+        "XML output must contain <dvcErrors> root; got: {xml:.200}"
+    );
+
+    // Each error must be wrapped in <error>.
+    assert!(
+        xml.contains("<error>"),
+        "XML output must contain <error> elements; got: {xml:.200}"
+    );
+
+    // The CHARSHAPE_FONT error code must appear.
+    assert!(
+        xml.contains("<errorCode>1004</errorCode>"),
+        "XML output must contain <errorCode>1004</errorCode>; got: {xml:.500}"
+    );
+
+    // A non-empty <text> element must be present.
+    assert!(
+        xml.contains("<text>"),
+        "XML output must contain <text> elements; got: {xml:.200}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pretty-print test
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// The pretty-printed output must contain the same semantic content as the
+/// compact output. Verified by checking that all element tags present in the
+/// compact form also appear in the pretty form.
+#[test]
+fn xml_output_pretty_contains_same_elements() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("Checker::run must not fail");
+
+    let compact = to_xml(&errors, false).expect("compact to_xml failed");
+    let pretty = to_xml(&errors, true).expect("pretty to_xml failed");
+
+    // Both must have the same root element.
+    assert!(compact.contains("<dvcErrors>"), "compact must have <dvcErrors>");
+    assert!(pretty.contains("<dvcErrors>"), "pretty must have <dvcErrors>");
+
+    // Pretty output must be longer (indentation adds bytes).
+    assert!(
+        pretty.len() > compact.len(),
+        "pretty output ({} bytes) should be longer than compact ({} bytes)",
+        pretty.len(),
+        compact.len()
+    );
+
+    // errorCode and text elements must appear in both.
+    for tag in &["<errorCode>", "<text>", "<charIDRef>", "<paraPrIDRef>"] {
+        assert!(compact.contains(tag), "compact missing {tag}");
+        assert!(pretty.contains(tag), "pretty missing {tag}");
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Empty input test
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `to_xml` on an empty slice must succeed and produce a well-formed XML
+/// document with an empty `<dvcErrors>` root.
+#[test]
+fn xml_output_empty_input() {
+    let xml = to_xml(&[], false).expect("to_xml(&[]) must not fail");
+
+    assert!(
+        xml.starts_with("<?xml"),
+        "empty output must start with XML declaration; got: {xml}"
+    );
+    assert!(
+        xml.contains("<dvcErrors>") && xml.contains("</dvcErrors>"),
+        "empty output must have dvcErrors open/close tags; got: {xml}"
+    );
+    // No <error> elements for empty input.
+    assert!(
+        !xml.contains("<error>"),
+        "empty output must not contain <error> elements; got: {xml}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `output::to_xml(&[DvcErrorInfo], pretty: bool) -> DvcResult<String>` in a new `crates/hwp-dvc-core/src/output/xml.rs` module using `quick-xml`'s writer API.
- Adds `Format::Xml` variant to the `output::Format` enum, both gated behind `#[cfg(feature = "xml")]`.
- `[features]` sections added to `hwp-dvc-core/Cargo.toml` (`xml = []`) and `hwp-dvc-cli/Cargo.toml` (`xml = ["hwp-dvc-core/xml"]`).
- CLI `--format xml` arm wired in `main.rs` behind `#[cfg(feature = "xml")]`.
- Integration test `tests/xml_output.rs` (gated with `#![cfg(feature = "xml")]`) loads `charshape_fail_font.hwpx` against `fixture_spec.json`, runs `Document::parse → Checker::run`, serialises to XML, and asserts `<errorCode>1004</errorCode>` and `<text>` are present.

## Test plan

- [ ] `cargo test --workspace` passes (feature off, JSON-only consumers unaffected)
- [ ] `cargo test --workspace --features xml` passes (3 XML integration tests green)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes (no feature flag)
- [ ] `cargo clippy --workspace --all-targets --features xml -- -D warnings` passes