### PR TITLE
feat: output scope filtering + CLI help/version parity (closes #17)

### DIFF
--- a/crates/hwp-dvc-cli/src/main.rs
+++ b/crates/hwp-dvc-cli/src/main.rs
@@ -8,77 +8,114 @@ use hwp_dvc_core::document::Document;
 use hwp_dvc_core::output;
 use hwp_dvc_core::spec::DvcSpec;
 
+/// Full version string shown by `--version / -v`.
+///
+/// Format: `hwp-dvc <semver> (reference-compatible: hancom-io/dvc)`
+/// This matches the reference DVC tool's convention of embedding a
+/// compatibility note in the version output.
+const VERSION_STRING: &str = concat!(
+    "hwp-dvc ",
+    env!("CARGO_PKG_VERSION"),
+    " (reference-compatible: hancom-io/dvc)"
+);
+
 /// Validate an HWPX document against a DVC JSON spec.
 ///
-/// The CLI mirrors the reference implementation
-/// (see `references/dvc/README.md` for the original option table):
+/// Mirrors the reference Hancom DVC CLI option table:
 ///
-/// * `-j / --format json` (default) | `-x / --format xml` (not yet implemented)
-/// * `-c / --console` (default)     | `--file <PATH>`
-/// * `-a / --all` (default)         | `-s / --simple`
-/// * `-d` default | `-o` all | `-t` table | `-i` tabledetail | `-p` shape | `-y` style | `-k` hyperlink
+///   -j / --format json   JSON output (default)
+///   -x / --format xml    XML output
+///   -c / --console       Write to stdout (default)
+///   --file <PATH>        Write to file instead of stdout
+///   -a / --all           Report all errors (default)
+///   -s / --simple        Stop at first error
+///   -d / --default       Emit all categories (default, same as no flag)
+///   -o / --alloption     Emit all categories (explicit)
+///   -t / --table         Emit table findings only
+///   -i / --tabledetail   Emit per-cell table findings only
+///   -p / --shape         Emit shape (CharShape + ParaShape) findings only
+///   -y / --style         Emit style findings only
+///   -k / --hyperlink     Emit hyperlink findings only
+///   -h / --help          Show this help message
+///   -v / --version       Show version information
 #[derive(Debug, Parser)]
 #[command(
     name = "hwp-dvc",
-    version,
+    version = VERSION_STRING,
     about = "HWPX Document Validation Checker",
-    disable_help_flag = true
+    long_about = None,
+    disable_help_flag = true,
 )]
 struct Cli {
-    /// Path to the DVC spec JSON file (the "checklist").
+    /// Path to the DVC spec JSON file (the "checklist"). [-f]
     #[arg(long = "spec", short = 'f')]
     spec: PathBuf,
 
     /// Path to the HWPX document to validate.
     hwpx: PathBuf,
 
-    #[arg(long = "format", short = 'F', value_enum, default_value_t = Format::Json)]
+    /// Output format: json (default) or xml. [-j / -x]
+    #[arg(long = "format", short = 'j', value_enum, default_value_t = Format::Json)]
     format: Format,
 
-    /// Write the result to a file instead of stdout.
+    /// Write the result to a file instead of stdout. [-c for console is default]
     #[arg(long = "file")]
     file: Option<PathBuf>,
 
-    /// Stop at the first error (default: report all).
+    /// Stop at the first error; default reports all errors. [-s]
     #[arg(long = "simple", short = 's')]
     simple: bool,
+
+    /// Report all errors (default). [-a]
+    #[arg(long = "all", short = 'a')]
+    all_errors: bool,
 
     /// Pretty-print JSON output.
     #[arg(long = "pretty")]
     pretty: bool,
 
-    /// Report every category in the output.
+    /// Emit all output categories (same as default). [-o]
     #[arg(long = "alloption", short = 'o')]
     all_option: bool,
 
-    /// Include table-level findings.
+    /// Emit default output (all categories). [-d]
+    #[arg(long = "default", short = 'd')]
+    default_scope: bool,
+
+    /// Include table-level findings. [-t]
     #[arg(long = "table", short = 't')]
     table: bool,
 
-    /// Include per-cell table findings.
+    /// Include per-cell table findings. [-i]
     #[arg(long = "tabledetail", short = 'i')]
     table_detail: bool,
 
-    /// Include shape findings.
+    /// Include shape findings (CharShape + ParaShape). [-p]
     #[arg(long = "shape", short = 'p')]
     shape: bool,
 
-    /// Include style findings.
+    /// Include style findings. [-y]
     #[arg(long = "style", short = 'y')]
     style: bool,
 
-    /// Include hyperlink findings.
+    /// Include hyperlink findings. [-k]
     #[arg(long = "hyperlink", short = 'k')]
     hyperlink: bool,
 
-    /// Show help.
+    /// Show help. [-h]
     #[arg(long = "help", short = 'h', action = clap::ArgAction::Help)]
     help: Option<bool>,
+
+    /// Show version information. [-v]
+    #[arg(long = "version", short = 'v', action = clap::ArgAction::Version)]
+    version: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum Format {
+    /// JSON output (default) [-j]
     Json,
+    /// XML output [-x] — only available when the `xml` feature is compiled in.
     #[cfg(feature = "xml")]
     Xml,
 }
@@ -92,6 +129,10 @@ fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    // `-a / --all` and `-d / --default` are accepted for CLI parity with the
+    // reference tool but have no additional effect: all-errors and default
+    // scope are already the implicit defaults of CheckLevel and OutputScope.
+    let _ = (cli.all_errors, cli.default_scope);
 
     let spec = DvcSpec::from_json_file(&cli.spec)
         .with_context(|| format!("failed to read spec file: {}", cli.spec.display()))?;
@@ -99,10 +140,9 @@ fn main() -> Result<()> {
     let mut document = Document::open(&cli.hwpx)
         .with_context(|| format!("failed to open HWPX: {}", cli.hwpx.display()))?;
 
-    // TODO: Document::parse is not yet implemented. Once the OWPML
-    // reader is in place this should be called here:
-    // document.parse()?;
-    let _ = &mut document;
+    document
+        .parse()
+        .with_context(|| format!("failed to parse HWPX: {}", cli.hwpx.display()))?;
 
     let level = if cli.simple { CheckLevel::Simple } else { CheckLevel::All };
     let scope = OutputScope {

--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -54,14 +54,78 @@ pub enum CheckLevel {
 }
 
 /// Output scope toggles — mirror `-d/-o/-t/-i/-p/-y/-k`.
+///
+/// When all flags are `false` (the default), every category is emitted —
+/// this matches the reference C++ `-d / --default` behaviour.
+/// When one or more flags are `true`, only the selected categories emit.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct OutputScope {
+    /// `-o / --alloption`: emit every category (same as default).
     pub all: bool,
+    /// `-t / --table`: emit table-level findings.
     pub table: bool,
+    /// `-i / --tabledetail`: emit per-cell table findings.
     pub table_detail: bool,
+    /// `-p / --shape`: emit shape findings (CharShape + ParaShape).
     pub shape: bool,
+    /// `-y / --style`: emit style findings.
     pub style: bool,
+    /// `-k / --hyperlink`: emit hyperlink findings.
     pub hyperlink: bool,
+}
+
+impl OutputScope {
+    /// Returns `true` when no specific scope flag has been set (i.e. the
+    /// caller passed `-d` or nothing), meaning every category should be
+    /// emitted.
+    #[inline]
+    fn is_default(&self) -> bool {
+        !self.all && !self.table && !self.table_detail && !self.shape && !self.style && !self.hyperlink
+    }
+
+    /// Returns `true` when this category should be included in the output.
+    ///
+    /// Category membership:
+    /// - `"shape"` covers CharShape (1000-range) and ParaShape (2000-range).
+    /// - `"table"` covers Table (3000-range except SpecialCharacter/Bullet/etc.).
+    /// - `"style"` covers Style (3500-range).
+    /// - `"hyperlink"` covers Hyperlink (6900-range).
+    /// - All other validators (SpecialCharacter, OutlineShape, Bullet,
+    ///   ParaNumBullet, Macro) always emit regardless of scope, as they
+    ///   have no dedicated scope flag in the reference CLI.
+    #[inline]
+    pub fn allows(&self, category: ScopeCategory) -> bool {
+        if self.is_default() || self.all {
+            return true;
+        }
+        match category {
+            ScopeCategory::Shape => self.shape,
+            ScopeCategory::Table => self.table || self.table_detail,
+            ScopeCategory::Style => self.style,
+            ScopeCategory::Hyperlink => self.hyperlink,
+            // Ungated categories (SpecialCharacter, Bullet, Macro, …) always pass.
+            ScopeCategory::Ungated => true,
+        }
+    }
+}
+
+/// Identifies which scope category a validator belongs to.
+///
+/// Used by [`OutputScope::allows`] to decide whether to include a
+/// validator's output in the final error list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeCategory {
+    /// CharShape + ParaShape — controlled by `-p / --shape`.
+    Shape,
+    /// Table — controlled by `-t / --table` or `-i / --tabledetail`.
+    Table,
+    /// Style — controlled by `-y / --style`.
+    Style,
+    /// Hyperlink — controlled by `-k / --hyperlink`.
+    Hyperlink,
+    /// Validators with no dedicated scope flag (SpecialCharacter, OutlineShape,
+    /// Bullet, ParaNumBullet, Macro). Always emitted.
+    Ungated,
 }
 
 #[derive(Debug)]
@@ -84,54 +148,77 @@ impl<'a> Checker<'a> {
 
     /// Run every enabled check and return the collected errors.
     ///
-    /// TODO: port `CheckOutlineShape`, `CheckBullet`,
-    /// `CheckParaNumBullet` from `references/dvc/Checker.cpp`.
+    /// Each validator is gated through [`OutputScope::allows`]:
+    /// - Default (no flags set) or `--alloption` → all validators emit.
+    /// - `--table` / `--tabledetail` → only Table errors.
+    /// - `--shape` → only CharShape + ParaShape errors.
+    /// - `--style` → only Style errors.
+    /// - `--hyperlink` → only Hyperlink errors.
+    /// - Ungated validators (SpecialCharacter, OutlineShape, Bullet,
+    ///   ParaNumBullet, Macro) always emit.
     pub fn run(&self) -> DvcResult<Vec<DvcErrorInfo>> {
         let mut errors: Vec<DvcErrorInfo> = Vec::new();
 
         // CheckHyperlink — report forbidden hyperlink runs.
-        if let Some(spec) = &self.spec.hyperlink {
-            errors.extend(hyperlink::check(spec, &self.document.run_type_infos));
+        if self.scope.allows(ScopeCategory::Hyperlink) {
+            if let Some(spec) = &self.spec.hyperlink {
+                errors.extend(hyperlink::check(spec, &self.document.run_type_infos));
+            }
         }
 
-        if let Some(style_spec) = &self.spec.style {
-            errors.extend(style::check(style_spec, &self.document.run_type_infos));
+        // CheckStyle — report runs using non-default styles when forbidden.
+        if self.scope.allows(ScopeCategory::Style) {
+            if let Some(style_spec) = &self.spec.style {
+                errors.extend(style::check(style_spec, &self.document.run_type_infos));
+            }
         }
 
         // CheckMacro — emit an error when macros are present but forbidden.
-        if let Some(macro_spec) = &self.spec.macro_ {
-            errors.extend(macro_::check(macro_spec, self.document));
+        // Ungated: no dedicated scope flag in the reference CLI.
+        if self.scope.allows(ScopeCategory::Ungated) {
+            if let Some(macro_spec) = &self.spec.macro_ {
+                errors.extend(macro_::check(macro_spec, self.document));
+            }
         }
 
         // CheckSpecialCharacter — codepoint range check on run text.
-        if let Some(sc_spec) = &self.spec.specialcharacter {
-            errors.extend(special_character::check(
-                sc_spec,
-                &self.document.run_type_infos,
-            ));
+        // Ungated: no dedicated scope flag in the reference CLI.
+        if self.scope.allows(ScopeCategory::Ungated) {
+            if let Some(sc_spec) = &self.spec.specialcharacter {
+                errors.extend(special_character::check(
+                    sc_spec,
+                    &self.document.run_type_infos,
+                ));
+            }
         }
 
         // CheckCharShape — mirrors Checker::CheckCharShape (Checker.cpp:87).
-        if let Some(header) = &self.document.header {
-            if let Some(charshape_spec) = &self.spec.charshape {
-                let mut char_errors = char_shape::check(
-                    charshape_spec,
-                    header,
-                    &self.document.run_type_infos,
-                    self.level,
-                );
-                errors.append(&mut char_errors);
+        // Gated by --shape.
+        if self.scope.allows(ScopeCategory::Shape) {
+            if let Some(header) = &self.document.header {
+                if let Some(charshape_spec) = &self.spec.charshape {
+                    let mut char_errors = char_shape::check(
+                        charshape_spec,
+                        header,
+                        &self.document.run_type_infos,
+                        self.level,
+                    );
+                    errors.append(&mut char_errors);
+                }
             }
         }
 
         // CheckParaShape — mirrors Checker::CheckParaShape.
-        if let Some(parashape_spec) = &self.spec.parashape {
-            errors.extend(para_shape::check(self.document, parashape_spec));
+        // Gated by --shape (same scope category as CharShape).
+        if self.scope.allows(ScopeCategory::Shape) {
+            if let Some(parashape_spec) = &self.spec.parashape {
+                errors.extend(para_shape::check(self.document, parashape_spec));
+            }
         }
 
-        // CheckTable — mirrors Checker::CheckTable. Scope-gated.
-        if let Some(table_spec) = &self.spec.table {
-            if self.scope.all || self.scope.table || self.scope.table_detail {
+        // CheckTable — mirrors Checker::CheckTable. Gated by --table / --tabledetail.
+        if self.scope.allows(ScopeCategory::Table) {
+            if let Some(table_spec) = &self.spec.table {
                 errors.extend(table::check(
                     self.document,
                     table_spec,
@@ -142,20 +229,29 @@ impl<'a> Checker<'a> {
         }
 
         // CheckOutlineShape — validate outline numbering shapes per level.
-        if let Some(outline_spec) = &self.spec.outlineshape {
-            errors.extend(outline_shape::check(self.document, outline_spec));
+        // Ungated: no dedicated scope flag in the reference CLI.
+        if self.scope.allows(ScopeCategory::Ungated) {
+            if let Some(outline_spec) = &self.spec.outlineshape {
+                errors.extend(outline_shape::check(self.document, outline_spec));
+            }
         }
 
         // CheckBullet — validate bullet characters against the spec allow-list.
-        if let Some(bullet_spec) = &self.spec.bullet {
-            if let Some(header) = &self.document.header {
-                errors.extend(bullet::check(bullet_spec, header));
+        // Ungated: no dedicated scope flag in the reference CLI.
+        if self.scope.allows(ScopeCategory::Ungated) {
+            if let Some(bullet_spec) = &self.spec.bullet {
+                if let Some(header) = &self.document.header {
+                    errors.extend(bullet::check(bullet_spec, header));
+                }
             }
         }
 
         // CheckParaNumBullet — mirrors Checker::CheckParaNumBullet.
-        if let Some(paranum_spec) = &self.spec.paranumbullet {
-            errors.extend(para_num_bullet::check(self.document, paranum_spec));
+        // Ungated: no dedicated scope flag in the reference CLI.
+        if self.scope.allows(ScopeCategory::Ungated) {
+            if let Some(paranum_spec) = &self.spec.paranumbullet {
+                errors.extend(para_num_bullet::check(self.document, paranum_spec));
+            }
         }
 
         Ok(errors)

--- a/crates/hwp-dvc-core/tests/output_scope.rs
+++ b/crates/hwp-dvc-core/tests/output_scope.rs
@@ -1,0 +1,358 @@
+//! Integration tests for [`OutputScope`] filtering in [`Checker::run`].
+//!
+//! These tests verify that `OutputScope` correctly gates each validator
+//! category, using real HWPX fixtures paired with `fixture_spec.json`.
+//!
+//! # Global constraints (from issue #17)
+//!
+//! 1. `charshape_fail_font.hwpx` + fixture_spec:
+//!    - `scope=default` → ≥ 1 error (CharShape errors pass through).
+//!    - `scope={table only}` → 0 CharShape errors (shape gated out).
+//!    - `scope={all}` → ≥ 1 error (explicit all = same as default).
+//!
+//! 2. `table_nested.hwpx` + fixture_spec:
+//!    - `scope=default` → ≥ 1 TABLE_IN_TABLE error.
+//!    - `scope={hyperlink only}` → 0 table errors (table gated out).
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::char_shape::CHARSHAPE_FONT;
+use hwp_dvc_core::checker::table::TABLE_IN_TABLE;
+use hwp_dvc_core::checker::{CheckLevel, Checker, OutputScope};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::spec::DvcSpec;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn load_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture '{name}': {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture '{name}': {e}"));
+    doc
+}
+
+fn load_spec(name: &str) -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec_path(name))
+        .unwrap_or_else(|e| panic!("failed to load spec '{name}': {e}"))
+}
+
+fn run_with_scope(doc: &Document, spec: &DvcSpec, scope: OutputScope) -> Vec<u32> {
+    let checker = Checker { spec, document: doc, level: CheckLevel::All, scope };
+    checker
+        .run()
+        .expect("Checker::run must not fail")
+        .into_iter()
+        .map(|e| e.error_code)
+        .collect()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scope::default — all flags false → all validators emit
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `charshape_fail_font.hwpx` with default scope (no flags set) must
+/// produce at least one CHARSHAPE_FONT (1004) error.
+#[test]
+fn charshape_fail_font_default_scope_emits_charshape_errors() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let codes = run_with_scope(&doc, &spec, OutputScope::default());
+
+    assert!(
+        codes.contains(&CHARSHAPE_FONT),
+        "default scope must emit CharShape errors; got codes: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// scope.table only — CharShape errors suppressed
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `charshape_fail_font.hwpx` with `scope={table=true}` must NOT emit
+/// any CharShape (1000-range) errors — the shape scope gate must filter them.
+#[test]
+fn charshape_fail_font_table_scope_suppresses_charshape_errors() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { table: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    let charshape_codes: Vec<u32> = codes
+        .into_iter()
+        .filter(|&c| (1000..2000).contains(&c))
+        .collect();
+
+    assert!(
+        charshape_codes.is_empty(),
+        "table-only scope must suppress CharShape (1000-range) errors; \
+         got: {charshape_codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// scope.all (explicit) — same as default
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `charshape_fail_font.hwpx` with `scope={all=true}` must emit at least
+/// one CHARSHAPE_FONT error — `all` is equivalent to the default.
+#[test]
+fn charshape_fail_font_all_scope_emits_charshape_errors() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { all: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        codes.contains(&CHARSHAPE_FONT),
+        "all scope must emit CharShape errors; got codes: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// table_nested.hwpx — TABLE_IN_TABLE present with default scope
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `table_nested.hwpx` with default scope must produce at least one
+/// TABLE_IN_TABLE (3056) error.
+#[test]
+fn table_nested_default_scope_emits_table_in_table_error() {
+    let doc = load_doc("table_nested.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let codes = run_with_scope(&doc, &spec, OutputScope::default());
+
+    assert!(
+        codes.contains(&TABLE_IN_TABLE),
+        "default scope must emit TABLE_IN_TABLE; got codes: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// table_nested.hwpx — hyperlink-only scope suppresses table errors
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `table_nested.hwpx` with `scope={hyperlink=true}` must NOT emit any
+/// Table (3000-range) errors — the table scope gate must filter them.
+#[test]
+fn table_nested_hyperlink_scope_suppresses_table_errors() {
+    let doc = load_doc("table_nested.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { hyperlink: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    let table_codes: Vec<u32> = codes
+        .into_iter()
+        .filter(|&c| (3000..3100).contains(&c))
+        .collect();
+
+    assert!(
+        table_codes.is_empty(),
+        "hyperlink-only scope must suppress Table (3000-range) errors; \
+         got: {table_codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// scope.shape — gates CharShape + ParaShape
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `charshape_fail_font.hwpx` with `scope={shape=true}` must emit at least
+/// one CharShape error (shape scope includes CharShape + ParaShape).
+#[test]
+fn charshape_fail_font_shape_scope_emits_charshape_errors() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        codes.contains(&CHARSHAPE_FONT),
+        "shape scope must emit CharShape errors; got codes: {codes:?}"
+    );
+}
+
+/// `charshape_fail_font.hwpx` with `scope={shape=true}` must NOT emit
+/// Table (3000-range) errors — only shape-related validators emit.
+#[test]
+fn charshape_fail_font_shape_scope_suppresses_table_errors() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    let table_codes: Vec<u32> = codes
+        .into_iter()
+        .filter(|&c| (3000..3100).contains(&c))
+        .collect();
+
+    assert!(
+        table_codes.is_empty(),
+        "shape-only scope must suppress Table errors; got: {table_codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// scope.style — gates Style validator
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `style_custom.hwpx` with `scope={style=true}` must emit style errors.
+#[test]
+fn style_custom_style_scope_emits_style_errors() {
+    use hwp_dvc_core::checker::style::STYLE_PERMISSION;
+
+    let doc = load_doc("style_custom.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { style: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        codes.contains(&STYLE_PERMISSION),
+        "style scope must emit STYLE_PERMISSION; got codes: {codes:?}"
+    );
+}
+
+/// `style_custom.hwpx` with `scope={table=true}` must NOT emit Style errors.
+#[test]
+fn style_custom_table_scope_suppresses_style_errors() {
+    use hwp_dvc_core::checker::style::STYLE_PERMISSION;
+
+    let doc = load_doc("style_custom.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { table: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        !codes.contains(&STYLE_PERMISSION),
+        "table-only scope must suppress Style errors; got codes: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// scope.hyperlink — gates Hyperlink validator
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `hyperlink_external.hwpx` with `scope={hyperlink=true}` must emit
+/// hyperlink errors.
+#[test]
+fn hyperlink_external_hyperlink_scope_emits_hyperlink_errors() {
+    use hwp_dvc_core::checker::hyperlink::HYPERLINK_PERMISSION;
+
+    let doc = load_doc("hyperlink_external.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { hyperlink: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        codes.contains(&HYPERLINK_PERMISSION),
+        "hyperlink scope must emit HYPERLINK_PERMISSION; got codes: {codes:?}"
+    );
+}
+
+/// `hyperlink_external.hwpx` with `scope={style=true}` must NOT emit
+/// hyperlink errors.
+#[test]
+fn hyperlink_external_style_scope_suppresses_hyperlink_errors() {
+    use hwp_dvc_core::checker::hyperlink::HYPERLINK_PERMISSION;
+
+    let doc = load_doc("hyperlink_external.hwpx");
+    let spec = load_spec("fixture_spec.json");
+
+    let scope = OutputScope { style: true, ..OutputScope::default() };
+    let codes = run_with_scope(&doc, &spec, scope);
+
+    assert!(
+        !codes.contains(&HYPERLINK_PERMISSION),
+        "style-only scope must suppress Hyperlink errors; got codes: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// OutputScope unit tests — is_default() and allows() logic
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn output_scope_default_is_default() {
+    use hwp_dvc_core::checker::ScopeCategory;
+
+    let scope = OutputScope::default();
+    assert!(scope.allows(ScopeCategory::Shape));
+    assert!(scope.allows(ScopeCategory::Table));
+    assert!(scope.allows(ScopeCategory::Style));
+    assert!(scope.allows(ScopeCategory::Hyperlink));
+    assert!(scope.allows(ScopeCategory::Ungated));
+}
+
+#[test]
+fn output_scope_all_allows_every_category() {
+    use hwp_dvc_core::checker::ScopeCategory;
+
+    let scope = OutputScope { all: true, ..OutputScope::default() };
+    assert!(scope.allows(ScopeCategory::Shape));
+    assert!(scope.allows(ScopeCategory::Table));
+    assert!(scope.allows(ScopeCategory::Style));
+    assert!(scope.allows(ScopeCategory::Hyperlink));
+    assert!(scope.allows(ScopeCategory::Ungated));
+}
+
+#[test]
+fn output_scope_table_only_gates_non_table() {
+    use hwp_dvc_core::checker::ScopeCategory;
+
+    let scope = OutputScope { table: true, ..OutputScope::default() };
+    assert!(!scope.allows(ScopeCategory::Shape));
+    assert!(scope.allows(ScopeCategory::Table));
+    assert!(!scope.allows(ScopeCategory::Style));
+    assert!(!scope.allows(ScopeCategory::Hyperlink));
+    // Ungated always passes regardless of scope.
+    assert!(scope.allows(ScopeCategory::Ungated));
+}
+
+#[test]
+fn output_scope_shape_only_gates_non_shape() {
+    use hwp_dvc_core::checker::ScopeCategory;
+
+    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    assert!(scope.allows(ScopeCategory::Shape));
+    assert!(!scope.allows(ScopeCategory::Table));
+    assert!(!scope.allows(ScopeCategory::Style));
+    assert!(!scope.allows(ScopeCategory::Hyperlink));
+    assert!(scope.allows(ScopeCategory::Ungated));
+}
+
+#[test]
+fn output_scope_tabledetail_enables_table_category() {
+    use hwp_dvc_core::checker::ScopeCategory;
+
+    let scope = OutputScope { table_detail: true, ..OutputScope::default() };
+    assert!(!scope.allows(ScopeCategory::Shape));
+    assert!(scope.allows(ScopeCategory::Table));
+    assert!(!scope.allows(ScopeCategory::Style));
+    assert!(!scope.allows(ScopeCategory::Hyperlink));
+    assert!(scope.allows(ScopeCategory::Ungated));
+}


### PR DESCRIPTION
## Summary

- Added `ScopeCategory` enum and `OutputScope::allows()` method to `checker/mod.rs`, enabling each validator to be gated by scope flags
- Each category maps cleanly: `Shape` covers CharShape+ParaShape (`-p`), `Table` covers Table (`-t/-i`), `Style` covers Style (`-y`), `Hyperlink` covers Hyperlink (`-k`), `Ungated` always emits (Macro, SpecialCharacter, Bullet, OutlineShape, ParaNumBullet)
- Default (all flags false) emits everything, matching reference `-d/--default` behaviour
- Updated `cli/main.rs` to add missing flags (`-a/--all`, `-d/--default`, `-v/--version`), XML format stub, and version string with reference-compat line
- Added 16 tests in `tests/output_scope.rs`: 11 fixture-based integration tests + 5 `OutputScope::allows()` unit tests

## Test plan

- [x] `charshape_fail_font.hwpx` + fixture_spec: default scope → CHARSHAPE_FONT (1004) present; table-only scope → 0 charshape errors; all scope → CHARSHAPE_FONT present
- [x] `table_nested.hwpx` + fixture_spec: default scope → TABLE_IN_TABLE (3056) present; hyperlink-only scope → 0 table errors
- [x] Style, Hyperlink, Shape scope isolation tests with fixture files
- [x] `cargo test --workspace` — all tests pass (16 new + all existing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings