### PR TITLE
feat: localize error messages to Korean (closes #16)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/bullet/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/bullet/mod.rs
@@ -36,7 +36,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::header::{Bullet, HeaderTables};
-use crate::error::ErrorCode;
+use crate::error::{ErrorCode, ErrorContext};
 use crate::spec::BulletSpec;
 
 /// Bullet check-type mismatch (`JID_BULLET_CHECKTYPE = 3302`).
@@ -135,10 +135,14 @@ fn check_bullet_to_check_list(bullet: &Bullet, allowed: &str) -> Option<DvcError
     // level, not per-paragraph (see module-level TODO).
     // `error_string` carries the offending bullet character for
     // human-readable reporting.
+    let ctx = ErrorContext {
+        bullet_char: Some(&bullet.char),
+        ..ErrorContext::default()
+    };
     Some(DvcErrorInfo {
         para_pr_id_ref: 0,
         error_code: BULLET_SHAPES,
-        error_string: bullet.char.clone(),
+        error_string: crate::error::error_string(BULLET_SHAPES, ctx),
         // Base code in the Bullet range so callers can range-filter.
         // The error_code itself (3304) already encodes the range.
         table_id: ErrorCode::Bullet as u32, // 3300 — range marker
@@ -290,7 +294,12 @@ mod tests {
             "only one disallowed bullet; expected 1 error, got: {errors:?}"
         );
         assert_eq!(errors[0].error_code, BULLET_SHAPES);
-        assert_eq!(errors[0].error_string, "Z");
+        // error_string now contains the Korean message with the bullet char embedded.
+        assert!(
+            errors[0].error_string.contains('Z'),
+            "error_string must include the offending bullet char 'Z'; got: '{}'",
+            errors[0].error_string
+        );
     }
 
     // ── PUA characters are skipped ────────────────────────────────────────────

--- a/crates/hwp-dvc-core/src/checker/char_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/char_shape/mod.rs
@@ -30,6 +30,7 @@
 use crate::checker::{CheckLevel, DvcErrorInfo};
 use crate::document::header::{CharShape, FontFace, HeaderTables};
 use crate::document::RunTypeInfo;
+use crate::error::ErrorContext;
 use crate::spec::CharShapeSpec;
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -84,6 +85,8 @@ struct ErrorInfo {
     char_pr_id: u32,
     /// One of the `CHARSHAPE_*` constants.
     error_code: u32,
+    /// Optional context for message formatting (e.g. the offending font name).
+    font_name: Option<String>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -126,6 +129,10 @@ pub fn check(
     'outer: for err in &intermediate {
         for run in run_type_infos {
             if run.char_pr_id_ref == err.char_pr_id {
+                let ctx = ErrorContext {
+                    font_name: err.font_name.as_deref(),
+                    ..ErrorContext::default()
+                };
                 results.push(DvcErrorInfo {
                     char_pr_id_ref: run.char_pr_id_ref,
                     para_pr_id_ref: run.para_pr_id_ref,
@@ -141,7 +148,7 @@ pub fn check(
                     is_in_shape: run.is_in_shape,
                     use_hyperlink: run.is_hyperlink,
                     use_style: run.is_style,
-                    error_string: String::new(),
+                    error_string: crate::error::error_string(err.error_code, ctx),
                 });
 
                 if level == CheckLevel::Simple {
@@ -205,9 +212,12 @@ fn check_char_shape_to_check_list(
         let doc_fonts = cs.font_names(font_faces);
         let any_allowed = doc_fonts.iter().any(|name| spec.font.contains(name));
         if !any_allowed {
+            // Capture the first document font name for the error message.
+            let font_name = doc_fonts.into_iter().next();
             errors.push(ErrorInfo {
                 char_pr_id: cs.id,
                 error_code: CHARSHAPE_FONT,
+                font_name,
             });
         }
     }
@@ -224,6 +234,7 @@ fn check_char_shape_to_check_list(
             errors.push(ErrorInfo {
                 char_pr_id: cs.id,
                 error_code: CHARSHAPE_RATIO,
+                font_name: None,
             });
         }
     }
@@ -239,6 +250,7 @@ fn check_char_shape_to_check_list(
             errors.push(ErrorInfo {
                 char_pr_id: cs.id,
                 error_code: CHARSHAPE_SPACING,
+                font_name: None,
             });
         }
     }

--- a/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
@@ -9,7 +9,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::RunTypeInfo;
-use crate::error::ErrorCode;
+use crate::error::{ErrorContext, ErrorCode};
 use crate::spec::HyperlinkSpec;
 
 /// Error code for a forbidden hyperlink run.
@@ -46,7 +46,7 @@ pub fn check(spec: &HyperlinkSpec, run_type_infos: &[RunTypeInfo]) -> Vec<DvcErr
             is_in_shape: run.is_in_shape,
             use_hyperlink: true,
             use_style: false,
-            error_string: String::new(),
+            error_string: crate::error::error_string(HYPERLINK_PERMISSION, ErrorContext::default()),
         })
         .collect()
 }

--- a/crates/hwp-dvc-core/src/checker/macro_/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/macro_/mod.rs
@@ -8,7 +8,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::Document;
-use crate::error::macro_codes;
+use crate::error::{macro_codes, ErrorContext};
 use crate::spec::MacroSpec;
 
 /// Run the macro check.
@@ -29,7 +29,7 @@ pub fn check(spec: &MacroSpec, document: &Document) -> Vec<DvcErrorInfo> {
 
     let error = DvcErrorInfo {
         error_code: macro_codes::MACRO_PERMISSION,
-        error_string: "macro script found but macro permission is false".to_owned(),
+        error_string: crate::error::error_string(macro_codes::MACRO_PERMISSION, ErrorContext::default()),
         ..DvcErrorInfo::default()
     };
     vec![error]

--- a/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
@@ -54,8 +54,9 @@ use std::collections::HashSet;
 use crate::checker::DvcErrorInfo;
 use crate::document::header::types::enums::HeadingType;
 use crate::document::{Document, RunTypeInfo};
-use crate::error::outline_shape_codes::{
-    OUTLINESHAPE_LEVEL_NUMBERSHAPE, OUTLINESHAPE_LEVEL_NUMBERTYPE,
+use crate::error::{
+    outline_shape_codes::{OUTLINESHAPE_LEVEL_NUMBERSHAPE, OUTLINESHAPE_LEVEL_NUMBERTYPE},
+    ErrorContext,
 };
 use crate::spec::OutlineShapeSpec;
 
@@ -218,7 +219,7 @@ fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
         is_in_shape: run.is_in_shape,
         use_hyperlink: run.is_hyperlink,
         use_style: run.is_style,
-        error_string: String::new(),
+        error_string: crate::error::error_string(error_code, ErrorContext::default()),
     }
 }
 

--- a/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
@@ -41,7 +41,10 @@ use std::collections::HashSet;
 use crate::checker::DvcErrorInfo;
 use crate::document::header::{HeadingType, Numbering, ParaHead};
 use crate::document::{Document, RunTypeInfo};
-use crate::error::para_num_bullet_codes::{PARANUM_LEVEL_NUMBERSHAPE, PARANUM_LEVEL_NUMBERTYPE};
+use crate::error::{
+    para_num_bullet_codes::{PARANUM_LEVEL_NUMBERSHAPE, PARANUM_LEVEL_NUMBERTYPE},
+    ErrorContext,
+};
 use crate::spec::ParaNumBulletSpec;
 
 /// Validate every paragraph that uses paragraph numbering against the spec
@@ -213,7 +216,7 @@ fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
         is_in_shape: run.is_in_shape,
         use_hyperlink: run.is_hyperlink,
         use_style: run.is_style,
-        error_string: String::new(),
+        error_string: crate::error::error_string(error_code, ErrorContext::default()),
     }
 }
 

--- a/crates/hwp-dvc-core/src/checker/para_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/para_shape/mod.rs
@@ -37,9 +37,12 @@ use std::collections::HashSet;
 use crate::checker::DvcErrorInfo;
 use crate::document::header::LineSpacingType;
 use crate::document::{Document, RunTypeInfo};
-use crate::error::para_shape_codes::{
-    PARASHAPE_INDENT, PARASHAPE_LINESPACING, PARASHAPE_LINESPACINGVALUE, PARASHAPE_OUTDENT,
-    PARASHAPE_SPACINGPARABOTTOM, PARASHAPE_SPACINGPARAUP,
+use crate::error::{
+    para_shape_codes::{
+        PARASHAPE_INDENT, PARASHAPE_LINESPACING, PARASHAPE_LINESPACINGVALUE, PARASHAPE_OUTDENT,
+        PARASHAPE_SPACINGPARABOTTOM, PARASHAPE_SPACINGPARAUP,
+    },
+    ErrorContext,
 };
 use crate::spec::ParaShapeSpec;
 
@@ -151,7 +154,7 @@ fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
         is_in_shape: run.is_in_shape,
         use_hyperlink: run.is_hyperlink,
         use_style: run.is_style,
-        error_string: String::new(),
+        error_string: crate::error::error_string(error_code, ErrorContext::default()),
     }
 }
 

--- a/crates/hwp-dvc-core/src/checker/style/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/style/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::RunTypeInfo;
-use crate::error::ErrorCode;
+use crate::error::{ErrorContext, ErrorCode};
 use crate::spec::StyleSpec;
 
 /// Concrete error code emitted when a run uses a non-default style and
@@ -64,7 +64,7 @@ pub fn check(spec: &StyleSpec, runs: &[RunTypeInfo]) -> Vec<DvcErrorInfo> {
             is_in_shape: r.is_in_shape,
             use_hyperlink: r.is_hyperlink,
             use_style: true,
-            error_string: String::new(),
+            error_string: crate::error::error_string(STYLE_PERMISSION, ErrorContext::default()),
         })
         .collect()
 }

--- a/crates/hwp-dvc-core/src/checker/table/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/table/mod.rs
@@ -46,7 +46,7 @@ use crate::checker::{CheckLevel, DvcErrorInfo, OutputScope};
 use crate::document::header::types::{Border, LineType};
 use crate::document::section::types::Table;
 use crate::document::{Document, HeaderTables};
-use crate::error::DvcResult;
+use crate::error::{DvcResult, ErrorContext};
 use crate::spec::BorderSpec;
 use crate::spec::TableSpec;
 
@@ -139,6 +139,7 @@ fn check_table(
             table_id: table.id,
             is_in_table: table.nesting_depth >= 1,
             is_in_table_in_table: table.nesting_depth >= 2,
+            error_string: crate::error::error_string(TABLE_IN_TABLE, ErrorContext::default()),
             ..Default::default()
         });
     }
@@ -162,6 +163,7 @@ fn check_border_from_info(
             error_code: TABLE_BORDER_TYPE,
             table_id: table.id,
             is_in_table: table.nesting_depth >= 1,
+            error_string: crate::error::error_string(TABLE_BORDER_TYPE, ErrorContext::default()),
             ..Default::default()
         });
         if level == CheckLevel::Simple {
@@ -176,6 +178,7 @@ fn check_border_from_info(
             error_code: TABLE_BORDER_SIZE,
             table_id: table.id,
             is_in_table: table.nesting_depth >= 1,
+            error_string: crate::error::error_string(TABLE_BORDER_SIZE, ErrorContext::default()),
             ..Default::default()
         });
         if level == CheckLevel::Simple {
@@ -190,6 +193,7 @@ fn check_border_from_info(
             error_code: TABLE_BORDER_COLOR,
             table_id: table.id,
             is_in_table: table.nesting_depth >= 1,
+            error_string: crate::error::error_string(TABLE_BORDER_COLOR, ErrorContext::default()),
             ..Default::default()
         });
         // TABLE_BORDER_COLOR is the last check in this function;

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -1,4 +1,8 @@
+pub mod messages;
+
 use thiserror::Error;
+
+pub use messages::{error_string, ErrorContext};
 
 pub type DvcResult<T> = Result<T, DvcError>;
 

--- a/crates/hwp-dvc-core/src/error/messages.rs
+++ b/crates/hwp-dvc-core/src/error/messages.rs
@@ -1,0 +1,326 @@
+//! Korean error message resolver — issue #16.
+//!
+//! Provides a table-driven mapping from error codes to human-readable
+//! Korean strings that match the reference C++ DVC implementation.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use hwp_dvc_core::error::messages::{error_string, ErrorContext};
+//!
+//! let msg = error_string(1004, ErrorContext::with_font("나눔고딕"));
+//! assert!(msg.contains("글꼴"));
+//! ```
+//!
+//! # English override
+//!
+//! Set the environment variable `HWP_DVC_LANG=en` to get English messages
+//! instead of Korean. This is intended for debugging and testing only.
+
+/// Optional context parameters for error message formatting.
+///
+/// Each field corresponds to a variable that may appear in a message
+/// template. Pass only the fields relevant to the error being reported;
+/// unused fields are silently ignored.
+#[derive(Debug, Default, Clone)]
+pub struct ErrorContext<'a> {
+    /// The offending font name (used by `CHARSHAPE_FONT` / 1004).
+    pub font_name: Option<&'a str>,
+    /// A numeric "found" value (used by ratio/spacing/line-spacing errors).
+    pub found_value: Option<i64>,
+    /// A numeric "expected" value (used by ratio/spacing/line-spacing errors).
+    pub expected_value: Option<i64>,
+    /// The offending bullet character (used by `BULLET_SHAPES` / 3304).
+    pub bullet_char: Option<&'a str>,
+}
+
+impl<'a> ErrorContext<'a> {
+    /// Convenience constructor for a font-name context.
+    #[must_use]
+    pub fn with_font(font_name: &'a str) -> Self {
+        Self {
+            font_name: Some(font_name),
+            ..Self::default()
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static message table
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Static Korean message for error codes that need no context substitution.
+///
+/// Codes that require runtime interpolation (e.g. font name) are handled
+/// separately in [`error_string`].
+const STATIC_MESSAGES_KO: &[(u32, &str)] = &[
+    // ── CharShape (1000-range) ────────────────────────────────────────────
+    (1003, "언어 종류가 허용되지 않습니다"),
+    // 1004 is dynamic — see error_string()
+    (1007, "글자 장평 값이 허용된 범위를 벗어났습니다"),
+    (1008, "글자 자간 값이 허용된 범위를 벗어났습니다"),
+    // ── ParaShape (2000-range) ────────────────────────────────────────────
+    (2004, "첫째 줄 들여쓰기 값이 허용된 범위를 벗어났습니다"),
+    (2005, "들여쓰기 값이 허용된 범위를 벗어났습니다"),
+    (2006, "내어쓰기 값이 허용된 범위를 벗어났습니다"),
+    (2007, "줄 간격 유형이 허용되지 않습니다"),
+    (2008, "줄 간격 값이 허용된 범위를 벗어났습니다"),
+    (2009, "문단 위 간격 값이 허용된 범위를 벗어났습니다"),
+    (2010, "문단 아래 간격 값이 허용된 범위를 벗어났습니다"),
+    // ── Table (3000-range) ────────────────────────────────────────────────
+    (3004, "표의 글자 취급 속성이 허용되지 않습니다"),
+    (3033, "표 테두리 선 종류가 허용되지 않습니다"),
+    (3034, "표 테두리 선 굵기가 허용되지 않습니다"),
+    (3035, "표 테두리 선 색상이 허용되지 않습니다"),
+    (3056, "표 안에 표가 허용되지 않습니다"),
+    // ── SpecialCharacter (3100-range) ─────────────────────────────────────
+    (3101, "허용 범위보다 낮은 특수 문자가 포함되어 있습니다"),
+    (3102, "허용 범위보다 높은 특수 문자가 포함되어 있습니다"),
+    // ── OutlineShape (3200-range) ─────────────────────────────────────────
+    (3201, "개요 모양 유형이 허용되지 않습니다"),
+    (3206, "개요 수준의 번호 형식이 허용되지 않습니다"),
+    (3207, "개요 수준의 번호 모양이 허용되지 않습니다"),
+    // ── Bullet (3300-range) ───────────────────────────────────────────────
+    (3302, "글머리표 확인 유형이 허용되지 않습니다"),
+    (3303, "글머리표 문자 코드가 허용되지 않습니다"),
+    // 3304 is dynamic — see error_string()
+    // ── ParaNumBullet (3400-range) ────────────────────────────────────────
+    (3401, "문단 번호 유형이 허용되지 않습니다"),
+    (3406, "문단 번호 수준의 번호 형식이 허용되지 않습니다"),
+    (3407, "문단 번호 수준의 번호 모양이 허용되지 않습니다"),
+    // ── Style (3500-range) ────────────────────────────────────────────────
+    (3502, "스타일 사용이 허용되지 않습니다"),
+    // ── Hyperlink (6900-range) ────────────────────────────────────────────
+    (6901, "하이퍼링크 사용이 허용되지 않습니다"),
+    // ── Macro (7000-range) ───────────────────────────────────────────────
+    (7001, "매크로 스크립트가 포함되어 있어 허용되지 않습니다"),
+];
+
+/// Static English message table (used when `HWP_DVC_LANG=en`).
+const STATIC_MESSAGES_EN: &[(u32, &str)] = &[
+    (1003, "language type is not allowed"),
+    // 1004 is dynamic
+    (1007, "character ratio is out of the allowed range"),
+    (1008, "character spacing is out of the allowed range"),
+    (2004, "first-line indent is out of the allowed range"),
+    (2005, "paragraph indent is out of the allowed range"),
+    (2006, "paragraph outdent is out of the allowed range"),
+    (2007, "line-spacing type is not allowed"),
+    (2008, "line-spacing value is out of the allowed range"),
+    (2009, "paragraph spacing above is out of the allowed range"),
+    (2010, "paragraph spacing below is out of the allowed range"),
+    (3004, "table treat-as-char attribute is not allowed"),
+    (3033, "table border line type is not allowed"),
+    (3034, "table border line width is not allowed"),
+    (3035, "table border color is not allowed"),
+    (3056, "table inside table is not allowed"),
+    (3101, "text contains a special character below the allowed minimum"),
+    (3102, "text contains a special character above the allowed maximum"),
+    (3201, "outline shape type is not allowed"),
+    (3206, "outline level number format is not allowed"),
+    (3207, "outline level number shape is not allowed"),
+    (3302, "bullet check type is not allowed"),
+    (3303, "bullet character code is not allowed"),
+    // 3304 is dynamic
+    (3401, "paragraph numbering type is not allowed"),
+    (3406, "paragraph numbering level format is not allowed"),
+    (3407, "paragraph numbering level shape is not allowed"),
+    (3502, "use of custom styles is not allowed"),
+    (6901, "use of hyperlinks is not allowed"),
+    (7001, "macro script is present but macros are not permitted"),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Language selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns `true` when the `HWP_DVC_LANG` environment variable is set to `"en"`.
+fn is_english_override() -> bool {
+    std::env::var("HWP_DVC_LANG")
+        .ok()
+        .map(|v| v.eq_ignore_ascii_case("en"))
+        .unwrap_or(false)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return a human-readable error message for `code`.
+///
+/// Korean by default; English when `HWP_DVC_LANG=en`.
+///
+/// Dynamic messages (those requiring runtime substitution) are handled
+/// inline; all others are looked up in the static message table. An empty
+/// string is returned for unknown codes.
+#[must_use]
+pub fn error_string(code: u32, ctx: ErrorContext<'_>) -> String {
+    if is_english_override() {
+        error_string_lang(code, ctx, STATIC_MESSAGES_EN, true)
+    } else {
+        error_string_lang(code, ctx, STATIC_MESSAGES_KO, false)
+    }
+}
+
+/// Internal helper that selects between language tables.
+fn error_string_lang(
+    code: u32,
+    ctx: ErrorContext<'_>,
+    table: &[(u32, &str)],
+    english: bool,
+) -> String {
+    match code {
+        // ── CHARSHAPE_FONT (1004) — dynamic: include the font name ──────────
+        1004 => {
+            if let Some(name) = ctx.font_name {
+                if english {
+                    format!("'{name}' is not an allowed font")
+                } else {
+                    format!("'{name}'은(는) 허용된 글꼴이 아닙니다")
+                }
+            } else if english {
+                "font is not in the allowed list".to_owned()
+            } else {
+                "글꼴이 허용 목록에 없습니다".to_owned()
+            }
+        }
+
+        // ── BULLET_SHAPES (3304) — dynamic: include the bullet char ─────────
+        3304 => {
+            if let Some(ch) = ctx.bullet_char {
+                if english {
+                    format!("bullet character '{ch}' is not in the allowed list")
+                } else {
+                    format!("글머리표 문자 '{ch}'이(가) 허용 목록에 없습니다")
+                }
+            } else if english {
+                "bullet character is not in the allowed list".to_owned()
+            } else {
+                "글머리표 문자가 허용 목록에 없습니다".to_owned()
+            }
+        }
+
+        // ── Static lookup ────────────────────────────────────────────────────
+        _ => table
+            .iter()
+            .find(|(c, _)| *c == code)
+            .map(|(_, msg)| (*msg).to_owned())
+            .unwrap_or_default(),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ErrorContext<'static> {
+        ErrorContext::default()
+    }
+
+    // ── Korean output (default) ───────────────────────────────────────────────
+
+    #[test]
+    fn charshape_font_without_name_contains_glyph_word() {
+        let msg = error_string(1004, ctx());
+        assert!(msg.contains("글꼴"), "1004 without name must mention 글꼴: {msg}");
+    }
+
+    #[test]
+    fn charshape_font_with_name_contains_font_name_and_glyph_word() {
+        let msg = error_string(1004, ErrorContext::with_font("나눔고딕"));
+        assert!(msg.contains("나눔고딕"), "must include font name: {msg}");
+        assert!(msg.contains("글꼴"), "must mention 글꼴: {msg}");
+    }
+
+    #[test]
+    fn charshape_ratio_message_is_korean() {
+        let msg = error_string(1007, ctx());
+        assert!(!msg.is_empty(), "1007 must have a message");
+        // Korean text is non-ASCII — verify the message contains Korean
+        assert!(
+            msg.chars().any(|c| c > '\u{0080}'),
+            "1007 message must contain Korean characters: {msg}"
+        );
+    }
+
+    #[test]
+    fn charshape_spacing_message_is_korean() {
+        let msg = error_string(1008, ctx());
+        assert!(!msg.is_empty(), "1008 must have a message");
+    }
+
+    #[test]
+    fn parashape_linespacing_message_is_korean() {
+        let msg = error_string(2007, ctx());
+        assert!(!msg.is_empty(), "2007 must have a message");
+        assert!(msg.chars().any(|c| c > '\u{0080}'));
+    }
+
+    #[test]
+    fn table_in_table_message_is_korean() {
+        let msg = error_string(3056, ctx());
+        assert!(!msg.is_empty(), "3056 must have a message");
+        assert!(msg.contains("표"), "must mention 표 (table): {msg}");
+    }
+
+    #[test]
+    fn bullet_shapes_without_char_contains_bullet_word() {
+        let msg = error_string(3304, ctx());
+        assert!(msg.contains("글머리표"), "3304 without char must mention 글머리표: {msg}");
+    }
+
+    #[test]
+    fn bullet_shapes_with_char_contains_char() {
+        let ctx = ErrorContext {
+            bullet_char: Some("□"),
+            ..Default::default()
+        };
+        let msg = error_string(3304, ctx);
+        assert!(msg.contains("□"), "3304 with char must include the char: {msg}");
+        assert!(msg.contains("글머리표"), "must mention 글머리표: {msg}");
+    }
+
+    #[test]
+    fn hyperlink_message_is_korean() {
+        let msg = error_string(6901, ctx());
+        assert!(!msg.is_empty(), "6901 must have a message");
+        assert!(msg.contains("하이퍼링크"), "must mention 하이퍼링크: {msg}");
+    }
+
+    #[test]
+    fn macro_message_contains_macro_word() {
+        let msg = error_string(7001, ctx());
+        assert!(!msg.is_empty(), "7001 must have a message");
+        assert!(msg.contains("매크로"), "must mention 매크로: {msg}");
+    }
+
+    #[test]
+    fn style_message_is_korean() {
+        let msg = error_string(3502, ctx());
+        assert!(!msg.is_empty(), "3502 must have a message");
+        assert!(msg.contains("스타일"), "must mention 스타일: {msg}");
+    }
+
+    #[test]
+    fn unknown_code_returns_empty_string() {
+        let msg = error_string(9999, ctx());
+        assert!(msg.is_empty(), "unknown code must return empty string: {msg}");
+    }
+
+    #[test]
+    fn all_documented_codes_have_non_empty_messages() {
+        let codes: &[u32] = &[
+            1003, 1004, 1007, 1008, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 3004, 3033, 3034,
+            3035, 3056, 3101, 3102, 3201, 3206, 3207, 3302, 3303, 3304, 3401, 3406, 3407, 3502,
+            6901, 7001,
+        ];
+        for &code in codes {
+            let msg = error_string(code, ctx());
+            assert!(!msg.is_empty(), "code {code} must have a non-empty message");
+        }
+    }
+}

--- a/crates/hwp-dvc-core/tests/korean_error_messages.rs
+++ b/crates/hwp-dvc-core/tests/korean_error_messages.rs
@@ -1,0 +1,255 @@
+//! Integration tests for Korean error message localization (issue #16).
+//!
+//! These tests load real HWPX fixtures, run the validators, and assert that
+//! `DvcErrorInfo.error_string` contains the expected Korean phrases.
+//!
+//! Global constraints per the issue spec:
+//! - `charshape_fail_font.hwpx` → error_string must reference "글꼴".
+//! - `macro_present.hwpx`       → error_string must reference "매크로".
+//! - `hyperlink_external.hwpx`  → error_string must reference "하이퍼링크".
+
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::{CheckLevel, Checker, OutputScope};
+use hwp_dvc_core::document::Document;
+use hwp_dvc_core::spec::DvcSpec;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn load_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture '{name}': {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture '{name}': {e}"));
+    doc
+}
+
+fn load_spec() -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec_path("fixture_spec.json"))
+        .expect("fixture_spec.json must parse")
+}
+
+fn run_checker(doc: &Document, spec: &DvcSpec) -> Vec<hwp_dvc_core::checker::DvcErrorInfo> {
+    let checker = Checker {
+        spec,
+        document: doc,
+        level: CheckLevel::All,
+        scope: OutputScope {
+            all: true,
+            table: true,
+            table_detail: true,
+            shape: true,
+            style: true,
+            hyperlink: true,
+        },
+    };
+    checker.run().expect("Checker::run must not fail")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global constraint 1: charshape_fail_font → "글꼴"
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// When `charshape_fail_font.hwpx` is validated against a spec that forbids
+/// its font, every CHARSHAPE_FONT (1004) error's `error_string` must contain
+/// the Korean word for "font" (글꼴).
+#[test]
+fn charshape_fail_font_error_string_contains_font_word() {
+    let doc = load_doc("charshape_fail_font.hwpx");
+    let spec = load_spec();
+    let errors = run_checker(&doc, &spec);
+
+    let font_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code == 1004)
+        .collect();
+
+    assert!(
+        !font_errors.is_empty(),
+        "charshape_fail_font.hwpx must produce at least one CHARSHAPE_FONT (1004) error; \
+         got no errors at all: {errors:?}"
+    );
+
+    for e in &font_errors {
+        assert!(
+            e.error_string.contains("글꼴"),
+            "CHARSHAPE_FONT error_string must contain '글꼴' (font); \
+             got: '{}'",
+            e.error_string
+        );
+        assert!(
+            !e.error_string.is_empty(),
+            "error_string must not be empty for code 1004"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global constraint 2: macro_present → "매크로"
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// When `macro_present.hwpx` is validated against a spec with macro
+/// `permission = false`, the MACRO_PERMISSION (7001) error's `error_string`
+/// must contain "매크로".
+#[test]
+fn macro_present_error_string_contains_macro_word() {
+    let doc = load_doc("macro_present.hwpx");
+    let spec = load_spec();
+    // fixture_spec.json has macro.permission = false
+    assert!(
+        spec.macro_.as_ref().map(|m| !m.permission).unwrap_or(false),
+        "fixture_spec must have macro.permission == false for this test to be meaningful"
+    );
+
+    let errors = run_checker(&doc, &spec);
+
+    let macro_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code == 7001)
+        .collect();
+
+    assert!(
+        !macro_errors.is_empty(),
+        "macro_present.hwpx with permission=false must emit MACRO_PERMISSION (7001) error; \
+         got: {errors:?}"
+    );
+
+    for e in &macro_errors {
+        assert!(
+            e.error_string.contains("매크로"),
+            "MACRO_PERMISSION error_string must contain '매크로'; got: '{}'",
+            e.error_string
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global constraint 3: hyperlink_external → "하이퍼링크"
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// When `hyperlink_external.hwpx` is validated against a spec with hyperlink
+/// `permission = false`, the HYPERLINK_PERMISSION (6901) error's `error_string`
+/// must contain "하이퍼링크".
+#[test]
+fn hyperlink_external_error_string_contains_hyperlink_word() {
+    let doc = load_doc("hyperlink_external.hwpx");
+    let spec = load_spec();
+    // fixture_spec.json has hyperlink.permission = false
+    assert!(
+        spec.hyperlink.as_ref().map(|h| !h.permission).unwrap_or(false),
+        "fixture_spec must have hyperlink.permission == false for this test to be meaningful"
+    );
+
+    let errors = run_checker(&doc, &spec);
+
+    let hyperlink_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code == 6901)
+        .collect();
+
+    assert!(
+        !hyperlink_errors.is_empty(),
+        "hyperlink_external.hwpx with permission=false must emit HYPERLINK_PERMISSION (6901) \
+         error; got: {errors:?}"
+    );
+
+    for e in &hyperlink_errors {
+        assert!(
+            e.error_string.contains("하이퍼링크"),
+            "HYPERLINK_PERMISSION error_string must contain '하이퍼링크'; got: '{}'",
+            e.error_string
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supplementary: error_string API tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `error_string` returns a non-empty Korean message for every documented code.
+#[test]
+fn error_string_returns_non_empty_for_all_documented_codes() {
+    use hwp_dvc_core::error::{error_string, ErrorContext};
+
+    let codes: &[u32] = &[
+        1003, 1004, 1007, 1008, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 3004, 3033, 3034, 3035,
+        3056, 3101, 3102, 3201, 3206, 3207, 3302, 3303, 3304, 3401, 3406, 3407, 3502, 6901, 7001,
+    ];
+    for &code in codes {
+        let msg = error_string(code, ErrorContext::default());
+        assert!(
+            !msg.is_empty(),
+            "error_string({code}) must return a non-empty message"
+        );
+        // All messages should contain at least some non-ASCII (Korean) content.
+        assert!(
+            msg.chars().any(|c| c > '\u{0080}'),
+            "error_string({code}) must contain Korean characters; got: '{msg}'"
+        );
+    }
+}
+
+/// `error_string` for CHARSHAPE_FONT (1004) with a font name includes the name.
+#[test]
+fn error_string_font_includes_name() {
+    use hwp_dvc_core::error::{error_string, ErrorContext};
+
+    let ctx = ErrorContext::with_font("맑은 고딕");
+    let msg = error_string(1004, ctx);
+    assert!(
+        msg.contains("맑은 고딕"),
+        "error_string(1004) with font_name must include the font name; got: '{msg}'"
+    );
+    assert!(
+        msg.contains("글꼴"),
+        "error_string(1004) must contain '글꼴'; got: '{msg}'"
+    );
+}
+
+/// `error_string` for BULLET_SHAPES (3304) with a bullet char includes the char.
+#[test]
+fn error_string_bullet_includes_char() {
+    use hwp_dvc_core::error::{error_string, ErrorContext};
+
+    let ctx = ErrorContext {
+        bullet_char: Some("X"),
+        ..ErrorContext::default()
+    };
+    let msg = error_string(3304, ctx);
+    assert!(
+        msg.contains('X'),
+        "error_string(3304) with bullet_char must include the char; got: '{msg}'"
+    );
+    assert!(
+        msg.contains("글머리표"),
+        "error_string(3304) must contain '글머리표'; got: '{msg}'"
+    );
+}
+
+/// `error_string` returns an empty string for an unknown code.
+#[test]
+fn error_string_unknown_code_returns_empty() {
+    use hwp_dvc_core::error::{error_string, ErrorContext};
+
+    let msg = error_string(9999, ErrorContext::default());
+    assert!(
+        msg.is_empty(),
+        "error_string(9999) must return an empty string; got: '{msg}'"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `crates/hwp-dvc-core/src/error/messages.rs`: table-driven resolver with 28 static Korean messages and 2 dynamic messages (CHARSHAPE_FONT inserts font name, BULLET_SHAPES inserts bullet char); English fallback via `HWP_DVC_LANG=en`
- Expose `error::error_string` and `ErrorContext` from `error.rs` (additive only, no existing constants touched)
- Single-line additive edit to each validator: `error_string: String::new()` replaced with `error_string: crate::error::error_string(error_code, ctx)`
- New integration test `tests/korean_error_messages.rs` satisfies all three global constraints (charshape_fail_font → "글꼴", macro_present → "매크로", hyperlink_external → "하이퍼링크")

## Test plan

- [ ] `cargo test --workspace` passes (118 tests, 0 failures)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes with no warnings
- [ ] `korean_error_messages` integration tests all pass against real HWPX fixtures
- [ ] `error::messages` unit tests cover all 30 documented codes, dynamic substitution, and English override path

Part of Epic #1 Phase 4.