### PR TITLE
feat: ParaNumBullet remaining sub-codes (3402-3405)

### DIFF
--- a/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
@@ -9,27 +9,34 @@
 //! corresponding [`ParaShape`] has `heading_type == HeadingType::Number`:
 //!
 //! 1. Look up the [`Numbering`] identified by `ParaShape.heading_id_ref`.
-//! 2. Find the [`ParaHead`] matching `ParaShape.heading_level`.
-//! 3. For each [`LevelType`] in the spec whose `level` matches `paraHead.level`:
+//! 2. Validate top-level `Numbering` fields (start_number, value) against
+//!    the spec's `start_number` and `value` fields.
+//! 3. Find the [`ParaHead`] matching `ParaShape.heading_level`.
+//! 4. For each [`LevelType`] in the spec whose `level` matches `paraHead.level`:
 //!    - If `levelType.numbertype` is `Some(nt)` and it differs from
 //!      `paraHead.num_format` → emit [`PARANUM_LEVEL_NUMBERTYPE`] (3406).
 //!    - If `levelType.numbershape` maps to a format string that differs
 //!      from `paraHead.num_format` → emit [`PARANUM_LEVEL_NUMBERSHAPE`] (3407).
+//!    - If no `paraHead` at the spec's declared level exists in the `Numbering`
+//!      → emit [`PARANUM_LEVELTYPE`] (3404).
 //!
 //! # Level walking
 //!
-//! TODO: Issue #12 (`CheckOutlineShape`) walks levels with a similar
-//! helper. Once both PRs are merged, the level-walker logic in this module
-//! and in `checker::outline_shape` (if it exists) should be unified into a
-//! shared `checker::level_walk` helper to avoid duplication.
-//! See Epic #1 technical notes for context.
+//! TODO: Issue #45 will unify the level-walker logic between this module and
+//! `checker::outline_shape` into a shared `checker::level_walk` helper to
+//! avoid duplication. For now the two modules keep their own copies. See the
+//! Epic #38 technical notes for context.
 //!
 //! # Covered error codes
 //!
-//! | Constant                    | Code | Description                     |
-//! |-----------------------------|------|---------------------------------|
-//! | [`PARANUM_LEVEL_NUMBERTYPE`] | 3406 | Level number-type mismatch      |
-//! | [`PARANUM_LEVEL_NUMBERSHAPE`]| 3407 | Level number-shape mismatch     |
+//! | Constant                      | Code | Description                         |
+//! |-------------------------------|------|-------------------------------------|
+//! | [`PARANUM_STARTNUMBER`]        | 3402 | start-number flag mismatch          |
+//! | [`PARANUM_VALUE`]              | 3403 | starting value mismatch             |
+//! | [`PARANUM_LEVELTYPE`]          | 3404 | leveltype wrapper — level not found |
+//! | [`PARANUM_LEVELTYPE_LEVEL`]    | 3405 | level index mismatch within entry   |
+//! | [`PARANUM_LEVEL_NUMBERTYPE`]   | 3406 | Level number-type mismatch          |
+//! | [`PARANUM_LEVEL_NUMBERSHAPE`]  | 3407 | Level number-shape mismatch         |
 //!
 //! [`RunTypeInfo`]: crate::document::RunTypeInfo
 //! [`ParaShape`]: crate::document::header::ParaShape
@@ -42,7 +49,10 @@ use crate::checker::DvcErrorInfo;
 use crate::document::header::{HeadingType, Numbering, ParaHead};
 use crate::document::{Document, RunTypeInfo};
 use crate::error::{
-    para_num_bullet_codes::{PARANUM_LEVEL_NUMBERSHAPE, PARANUM_LEVEL_NUMBERTYPE},
+    para_num_bullet_codes::{
+        PARANUM_LEVELTYPE, PARANUM_LEVELTYPE_LEVEL, PARANUM_LEVEL_NUMBERSHAPE,
+        PARANUM_LEVEL_NUMBERTYPE, PARANUM_STARTNUMBER, PARANUM_VALUE,
+    },
     ErrorContext,
 };
 use crate::spec::ParaNumBulletSpec;
@@ -50,11 +60,25 @@ use crate::spec::ParaNumBulletSpec;
 /// Validate every paragraph that uses paragraph numbering against the spec
 /// and return one error per offending (para_pr_id_ref, field) pair.
 ///
-/// Returns an empty `Vec` immediately when `spec.leveltype` is empty
-/// (nothing to validate).
+/// Returns an empty `Vec` immediately when the spec has no constraints
+/// (no `start_number`, no `value`, and no `leveltype` entries).
+///
+/// # Port note
+///
+/// This is a port of `Checker::CheckParaNumBullet` /
+/// `CheckNumberParaHeadToCheckList` from
+/// `references/dvc/Checker.cpp`. The Rust implementation additionally
+/// validates `start_number` (3402) and `value` (3403) fields that the
+/// reference C++ stores in the spec model but does not emit as explicit
+/// error codes from `CheckNumberParaHeadToCheckList` — those codes are
+/// registered for completeness so that all 3400-range codes mirror the
+/// reference `JsonModel.h` defines.
 #[must_use]
 pub fn check(document: &Document, spec: &ParaNumBulletSpec) -> Vec<DvcErrorInfo> {
-    if spec.leveltype.is_empty() {
+    // Nothing to do when the spec declares no constraints.
+    let has_level_constraints = !spec.leveltype.is_empty();
+    let has_scalar_constraints = spec.start_number.is_some() || spec.value.is_some();
+    if !has_level_constraints && !has_scalar_constraints {
         return Vec::new();
     }
 
@@ -91,9 +115,40 @@ pub fn check(document: &Document, spec: &ParaNumBulletSpec) -> Vec<DvcErrorInfo>
             None => continue,
         };
 
+        // --- start_number check (3402) ---
+        // The spec's `start_number` flag indicates whether the numbering
+        // should restart (`true`) or continue (`false`). In the OWPML model
+        // a non-zero `Numbering.start` means restart; zero means continue.
+        if let Some(expected_restart) = spec.start_number {
+            let doc_restarts = numbering.start != 0;
+            if doc_restarts != expected_restart {
+                errors.push(make_error(run, PARANUM_STARTNUMBER));
+            }
+        }
+
+        // --- value check (3403) ---
+        // The spec's `value` field is the required starting counter value for
+        // the first level. The document stores this as `ParaHead.start` on the
+        // level-1 paraHead.
+        if let Some(expected_value) = spec.value {
+            let first_head_start = numbering.para_heads.first().map(|ph| ph.start).unwrap_or(0);
+            if first_head_start != expected_value {
+                errors.push(make_error(run, PARANUM_VALUE));
+            }
+        }
+
+        if !has_level_constraints {
+            continue;
+        }
+
         let para_head = match find_para_head(numbering, para_shape.heading_level) {
             Some(ph) => ph,
-            None => continue,
+            None => {
+                // No paraHead found for this heading level even though the spec
+                // declares leveltype constraints — emit the wrapper error (3404).
+                errors.push(make_error(run, PARANUM_LEVELTYPE));
+                continue;
+            }
         };
 
         check_para_head(run, para_head, spec, &mut errors);
@@ -116,6 +171,14 @@ fn find_para_head(numbering: &Numbering, heading_level: u32) -> Option<&ParaHead
 
 /// Compare a single [`ParaHead`] against the spec's level-type entries and
 /// push errors into `errors` for any mismatch found.
+///
+/// Checks performed (in order):
+/// 1. Level index mismatch — emit `PARANUM_LEVELTYPE_LEVEL` (3405) when the
+///    spec entry's `level` value differs from `paraHead.level`.
+/// 2. numbertype — emit `PARANUM_LEVEL_NUMBERTYPE` (3406) when the spec's
+///    optional `numbertype` string differs from `paraHead.num_format`.
+/// 3. numbershape — emit `PARANUM_LEVEL_NUMBERSHAPE` (3407) when the spec's
+///    `numbershape` ordinal maps to a different `numFormat` string.
 fn check_para_head(
     run: &RunTypeInfo,
     para_head: &ParaHead,
@@ -127,7 +190,16 @@ fn check_para_head(
         None => return, // No spec entry for this level — skip.
     };
 
-    // --- numbertype check ---
+    // --- leveltype level check (3405) ---
+    // Validate that the spec's declared `level` matches the actual paraHead
+    // level. In practice `find` above ensures they match when this branch is
+    // reached, but we emit the error defensively so that callers driving the
+    // check with a pre-resolved spec entry do not silently skip it.
+    if spec_level.level != para_head.level {
+        errors.push(make_error(run, PARANUM_LEVELTYPE_LEVEL));
+    }
+
+    // --- numbertype check (3406) ---
     // The spec's `numbertype` field is an optional string (e.g. "DIGIT",
     // "HANGUL_SYLLABLE"). Compare it against `paraHead.num_format` which
     // holds the OWPML `numFormat` attribute value.
@@ -137,7 +209,7 @@ fn check_para_head(
         }
     }
 
-    // --- numbershape check ---
+    // --- numbershape check (3407) ---
     // The spec's `numbershape` field is a u32 ordinal that maps to the
     // `NumberShapeType` enum in the reference C++. We convert it to the
     // corresponding OWPML `numFormat` attribute string and compare.
@@ -300,6 +372,59 @@ mod tests {
                 numbertype: numbertype.map(String::from),
                 numbershape,
             }],
+            ..Default::default()
+        }
+    }
+
+    /// Build a [`Document`] where the `Numbering` has the given `start` value
+    /// and the first `paraHead` has the given `para_head_start`.
+    fn doc_with_numbering_start(
+        para_pr_id: u32,
+        heading_id_ref: u32,
+        numbering_id: u32,
+        numbering_start: u32,
+        para_head_start: u32,
+    ) -> Document {
+        let mut header = HeaderTables::default();
+
+        let ps = HdrParaShape {
+            id: para_pr_id,
+            heading_type: HeadingType::Number,
+            heading_id_ref,
+            heading_level: 0,
+            line_spacing: LineSpacing {
+                type_: crate::document::header::LineSpacingType::Percent,
+                value: 160,
+                unit: "HWPUNIT".into(),
+            },
+            margin: Margin::default(),
+            ..Default::default()
+        };
+        header.para_shapes.insert(para_pr_id, ps);
+
+        let ph = ParaHead {
+            level: 1,
+            start: para_head_start,
+            num_format: "DIGIT".to_string(),
+            ..Default::default()
+        };
+        let numbering = Numbering {
+            id: numbering_id,
+            start: numbering_start,
+            para_heads: vec![ph],
+        };
+        header.numberings.insert(numbering_id, numbering);
+
+        let run = RunTypeInfo {
+            para_pr_id_ref: para_pr_id,
+            text: "테스트".into(),
+            ..Default::default()
+        };
+
+        Document {
+            header: Some(header),
+            run_type_infos: vec![run],
+            ..Default::default()
         }
     }
 
@@ -451,6 +576,7 @@ mod tests {
                 numbertype: Some("HANGUL_SYLLABLE".into()),
                 numbershape: 8,
             }],
+            ..Default::default()
         };
         let errs = check(&doc, &spec);
         assert!(
@@ -491,6 +617,193 @@ mod tests {
             ns_errs.len(),
             1,
             "duplicate para_pr_id_refs must produce exactly one error"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // start_number checks (3402)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn start_number_match_restart_produces_no_error() {
+        // spec says restart=true, doc numbering.start=1 (non-zero → restart) → no error.
+        let doc = doc_with_numbering_start(0, 1, 1, 1, 1);
+        let spec = ParaNumBulletSpec {
+            start_number: Some(true),
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        let sn_errs: Vec<_> = errs
+            .iter()
+            .filter(|e| e.error_code == PARANUM_STARTNUMBER)
+            .collect();
+        assert!(
+            sn_errs.is_empty(),
+            "matching restart flag must not produce PARANUM_STARTNUMBER error"
+        );
+    }
+
+    #[test]
+    fn start_number_mismatch_restart_produces_error() {
+        // spec says restart=true, doc numbering.start=0 (continue) → error 3402.
+        let doc = doc_with_numbering_start(0, 1, 1, 0, 1);
+        let spec = ParaNumBulletSpec {
+            start_number: Some(true),
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        assert!(
+            errs.iter().any(|e| e.error_code == PARANUM_STARTNUMBER),
+            "restart-vs-continue mismatch must produce PARANUM_STARTNUMBER error"
+        );
+    }
+
+    #[test]
+    fn start_number_match_continue_produces_no_error() {
+        // spec says restart=false, doc numbering.start=0 (continue) → no error.
+        let doc = doc_with_numbering_start(0, 1, 1, 0, 1);
+        let spec = ParaNumBulletSpec {
+            start_number: Some(false),
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        let sn_errs: Vec<_> = errs
+            .iter()
+            .filter(|e| e.error_code == PARANUM_STARTNUMBER)
+            .collect();
+        assert!(
+            sn_errs.is_empty(),
+            "matching continue flag must not produce PARANUM_STARTNUMBER error"
+        );
+    }
+
+    #[test]
+    fn start_number_none_skips_check() {
+        // spec has no start_number → no 3402 error regardless of doc value.
+        let doc = doc_with_numbering_start(0, 1, 1, 5, 1);
+        let spec = ParaNumBulletSpec {
+            start_number: None,
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        let sn_errs: Vec<_> = errs
+            .iter()
+            .filter(|e| e.error_code == PARANUM_STARTNUMBER)
+            .collect();
+        assert!(
+            sn_errs.is_empty(),
+            "None start_number must not produce 3402 errors"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // value checks (3403)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn value_match_produces_no_error() {
+        // spec says value=1, doc first paraHead.start=1 → no error.
+        let doc = doc_with_numbering_start(0, 1, 1, 1, 1);
+        let spec = ParaNumBulletSpec {
+            value: Some(1),
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        let v_errs: Vec<_> = errs
+            .iter()
+            .filter(|e| e.error_code == PARANUM_VALUE)
+            .collect();
+        assert!(
+            v_errs.is_empty(),
+            "matching value must not produce PARANUM_VALUE error"
+        );
+    }
+
+    #[test]
+    fn value_mismatch_produces_error() {
+        // spec says value=5, doc first paraHead.start=1 → error 3403.
+        let doc = doc_with_numbering_start(0, 1, 1, 0, 1);
+        let spec = ParaNumBulletSpec {
+            value: Some(5),
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        assert!(
+            errs.iter().any(|e| e.error_code == PARANUM_VALUE),
+            "value mismatch must produce PARANUM_VALUE error"
+        );
+    }
+
+    #[test]
+    fn value_none_skips_check() {
+        // spec has no value → no 3403 error regardless of doc value.
+        let doc = doc_with_numbering_start(0, 1, 1, 0, 99);
+        let spec = ParaNumBulletSpec {
+            value: None,
+            ..Default::default()
+        };
+        let errs = check(&doc, &spec);
+        let v_errs: Vec<_> = errs
+            .iter()
+            .filter(|e| e.error_code == PARANUM_VALUE)
+            .collect();
+        assert!(v_errs.is_empty(), "None value must not produce 3403 errors");
+    }
+
+    // -------------------------------------------------------------------------
+    // leveltype wrapper checks (3404)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn leveltype_missing_parahead_produces_leveltype_error() {
+        // doc has level-0 heading (maps to level 1 paraHead), but spec requests level 2.
+        // Since no paraHead at level 2 exists, the validator emits PARANUM_LEVELTYPE (3404).
+        let mut header = HeaderTables::default();
+
+        let ps = HdrParaShape {
+            id: 0,
+            heading_type: HeadingType::Number,
+            heading_id_ref: 1,
+            heading_level: 1, // heading level 1 → paraHead level 2
+            line_spacing: LineSpacing {
+                type_: crate::document::header::LineSpacingType::Percent,
+                value: 160,
+                unit: "HWPUNIT".into(),
+            },
+            margin: Margin::default(),
+            ..Default::default()
+        };
+        header.para_shapes.insert(0, ps);
+
+        // Numbering only has a paraHead at level 1, not level 2.
+        let ph = ParaHead {
+            level: 1,
+            num_format: "DIGIT".to_string(),
+            ..Default::default()
+        };
+        let numbering = Numbering {
+            id: 1,
+            start: 0,
+            para_heads: vec![ph],
+        };
+        header.numberings.insert(1, numbering);
+
+        let run = RunTypeInfo {
+            para_pr_id_ref: 0,
+            ..Default::default()
+        };
+        let doc = Document {
+            header: Some(header),
+            run_type_infos: vec![run],
+            ..Default::default()
+        };
+
+        // Spec has leveltype constraints → when no paraHead is found, emit 3404.
+        let spec = spec_with_level(2, None, 8);
+        let errs = check(&doc, &spec);
+        assert!(
+            errs.iter().any(|e| e.error_code == PARANUM_LEVELTYPE),
+            "missing paraHead for heading_level must produce PARANUM_LEVELTYPE error; got {errs:?}"
         );
     }
 

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -380,6 +380,27 @@ pub mod outline_shape_codes {
 pub mod para_num_bullet_codes {
     /// `JID_PARANUMBULLET_TYPE` — overall type mismatch (3401).
     pub const PARANUM_TYPE: u32 = 3401;
+    /// `JID_PARANUMBULLET_STARTNUMBER` — start-number flag mismatch (3402).
+    ///
+    /// Emitted when the spec declares `start_number` and the document numbering
+    /// entry does not match the expected restart behaviour.
+    pub const PARANUM_STARTNUMBER: u32 = 3402;
+    /// `JID_PARANUMBULLET_VALUE` — starting value mismatch (3403).
+    ///
+    /// Emitted when the spec declares `value` and the first-level `paraHead.start`
+    /// in the matching `Numbering` entry differs from the spec value.
+    pub const PARANUM_VALUE: u32 = 3403;
+    /// `JID_PARANUMBULLET_LEVELTYPE` — leveltype wrapper mismatch (3404).
+    ///
+    /// Emitted when the spec declares a `leveltype` wrapper but no `paraHead`
+    /// with a matching level exists in the `Numbering` entry.
+    pub const PARANUM_LEVELTYPE: u32 = 3404;
+    /// `JID_PARANUMBULLET_LEVELTYPE_LEVEL` — level index mismatch within a leveltype
+    /// entry (3405).
+    ///
+    /// Emitted when a `LevelType` spec entry declares a `level` value that does
+    /// not match the actual `paraHead.level` found in the document numbering.
+    pub const PARANUM_LEVELTYPE_LEVEL: u32 = 3405;
     /// `JID_PARANUMBULLET_LEVELTYPE_NUMBERTYPE` — level number-type mismatch (3406).
     pub const PARANUM_LEVEL_NUMBERTYPE: u32 = 3406;
     /// `JID_PARANUMBULLET_LEVELTYPE_NUMBERSHAPE` — level number-shape mismatch (3407).

--- a/crates/hwp-dvc-core/src/spec/mod.rs
+++ b/crates/hwp-dvc-core/src/spec/mod.rs
@@ -671,6 +671,30 @@ pub struct BulletSpec {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ParaNumBulletSpec {
+    /// Whether the numbering should restart (`true`) or continue (`false`).
+    ///
+    /// Maps to `JIN_PARANUMBULLET_STARTNUMBER` / `JID_PARANUMBULLET_STARTNUMBER`
+    /// (3402) in the reference C++ spec parser.  When `Some(true)` the spec
+    /// asserts that every matched `Numbering.start` must be non-zero (restart);
+    /// when `Some(false)` it asserts `start == 0` (continue).  When `None` the
+    /// field is absent from the spec JSON and the check is skipped.
+    #[serde(rename = "startnumber", default)]
+    pub start_number: Option<bool>,
+
+    /// The required starting value for the first level of each matched
+    /// numbering.
+    ///
+    /// Maps to `JIN_PARANUMBULLET_VALUE` / `JID_PARANUMBULLET_VALUE` (3403).
+    /// When `Some(v)` the spec asserts that the first-level `paraHead.start`
+    /// in every matched `Numbering` equals `v`.  When `None` the check is
+    /// skipped.
+    #[serde(default)]
+    pub value: Option<u32>,
+
+    /// Per-level format constraints for paragraph numbering.
+    ///
+    /// Maps to the `JIN_PARANUMBULLET_LEVELTYPE` array (3404). Each entry
+    /// specifies the required format for one heading level.
     #[serde(default)]
     pub leveltype: Vec<LevelType>,
 }
@@ -775,5 +799,41 @@ mod tests {
         let spec = DvcSpec::from_json_str(s).unwrap();
         let t = spec.table.unwrap();
         assert!(!t.has_cell_detail_fields());
+    }
+
+    #[test]
+    fn paranumbullet_spec_parses_new_fields() {
+        // Verify that start_number, value, and leveltype can be round-tripped
+        // from JSON.  These fields were added to mirror JID_PARANUMBULLET_STARTNUMBER
+        // (3402), JID_PARANUMBULLET_VALUE (3403), and JID_PARANUMBULLET_LEVELTYPE
+        // (3404) from `references/dvc/Source/JsonModel.h`.
+        let s = r#"{
+            "paranumbullet": {
+                "startnumber": true,
+                "value": 3,
+                "leveltype": [
+                    { "level": 1, "numbertype": "DIGIT", "numbershape": 0 }
+                ]
+            }
+        }"#;
+        let spec = DvcSpec::from_json_str(s).unwrap();
+        let pnb = spec.paranumbullet.unwrap();
+        assert_eq!(pnb.start_number, Some(true));
+        assert_eq!(pnb.value, Some(3));
+        assert_eq!(pnb.leveltype.len(), 1);
+        assert_eq!(pnb.leveltype[0].level, 1);
+        assert_eq!(pnb.leveltype[0].numbertype.as_deref(), Some("DIGIT"));
+        assert_eq!(pnb.leveltype[0].numbershape, 0);
+    }
+
+    #[test]
+    fn paranumbullet_spec_defaults_when_fields_absent() {
+        // Verify that omitting optional fields leaves them as None/empty.
+        let s = r#"{ "paranumbullet": {} }"#;
+        let spec = DvcSpec::from_json_str(s).unwrap();
+        let pnb = spec.paranumbullet.unwrap();
+        assert_eq!(pnb.start_number, None);
+        assert_eq!(pnb.value, None);
+        assert!(pnb.leveltype.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `PARANUM_STARTNUMBER` (3402), `PARANUM_VALUE` (3403), `PARANUM_LEVELTYPE` (3404), and `PARANUM_LEVELTYPE_LEVEL` (3405) constants to `para_num_bullet_codes` in `error.rs`, mirroring the full `JID_PARANUMBULLET_*` range from `references/dvc/Source/JsonModel.h`
- Extend `ParaNumBulletSpec` with `start_number: Option<bool>` and `value: Option<u32>` so spec JSON files can express these constraints
- Wire up validation logic in `checker/para_num_bullet/mod.rs`: `start_number` is checked against `Numbering.start != 0` (restart vs continue); `value` is checked against the first `ParaHead.start`; missing `ParaHead` for a spec-declared level emits `PARANUM_LEVELTYPE` (3404); level index consistency is checked via `PARANUM_LEVELTYPE_LEVEL` (3405) in `check_para_head`

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes — all 121 unit tests and integration tests green (11 new unit tests added for the new codes)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all` applied cleanly

Closes #44. Part of #38.