### PR TITLE
feat: Style type allow-list (JID_STYLE_TYPE) redesign

### DIFF
--- a/crates/hwp-dvc-core/src/checker/style/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/style/mod.rs
@@ -3,33 +3,62 @@
 //!
 //! # Logic
 //!
-//! When the spec carries `"style": { "permission": false }`, every
-//! [`RunTypeInfo`] whose `is_style == true` (i.e. whose paragraph was
-//! formatted with a non-default style, meaning any style other than
-//! "바탕글") produces one [`DvcErrorInfo`] with `error_code` in the
-//! [`ErrorCode::Style`] (3500) range.
+//! Two independent checks are performed, each governed by a different
+//! field in [`StyleSpec`]:
 //!
-//! When `permission == true`, no errors are emitted — the document is
-//! free to use custom styles.
+//! ## 1. Permission gate (error 3502, `STYLE_PERMISSION`)
 //!
-//! The error code emitted per run is [`STYLE_PERMISSION`] (3502),
-//! following the reference's scheme where 3500 is the category base
-//! and individual sub-codes are offset from it.
+//! When `spec.permission == false`, every [`RunTypeInfo`] whose
+//! `is_style == true` (paragraph uses a style other than 바탕글)
+//! produces one [`DvcErrorInfo`] with error code 3502.
+//!
+//! When `permission == true`, no 3502 errors are emitted.
+//!
+//! ## 2. Type allow-list (error 3501, `STYLE_TYPE`)
+//!
+//! When `spec.allowed_types` is non-empty, every run whose paragraph
+//! `style_name` is **not** in the allowed list produces one
+//! [`DvcErrorInfo`] with error code 3501.
+//!
+//! This check fires regardless of the `permission` flag — a document
+//! may allow custom styles in general but still restrict which
+//! logical style types are valid.
+//!
+//! When `allowed_types` is absent or empty, no 3501 errors are emitted.
+//!
+//! The error codes mirror `JID_STYLE_TYPE` (3501) and
+//! `JID_STYLE_PERMISSION` (3502) from
+//! `references/dvc/Source/JsonModel.h`.
 //!
 //! [`RunTypeInfo`]: crate::document::RunTypeInfo
 
 use crate::checker::DvcErrorInfo;
 use crate::document::RunTypeInfo;
-use crate::error::{ErrorCode, ErrorContext};
+use crate::error::{style_codes, ErrorCode, ErrorContext};
 use crate::spec::StyleSpec;
 
-/// Concrete error code emitted when a run uses a non-default style and
-/// `StyleSpec.permission == false`. Offset from the `Style` base (3500)
-/// to leave room for the category base itself and a future "allowed
-/// style list" code at 3501.
-pub const STYLE_PERMISSION: u32 = ErrorCode::Style as u32 + 2;
+// Re-export the canonical constants so that callers that import from
+// this module do not also need to import `crate::error::style_codes`.
+pub use style_codes::STYLE_PERMISSION;
+pub use style_codes::STYLE_TYPE;
 
-/// Run the style check over a slice of [`RunTypeInfo`]s.
+/// Guard: `STYLE_PERMISSION` must be in the Style (3500) range.
+const _: () = assert!(
+    STYLE_PERMISSION >= ErrorCode::Style as u32,
+    "STYLE_PERMISSION must be >= Style base (3500)",
+);
+const _: () = assert!(
+    STYLE_TYPE >= ErrorCode::Style as u32,
+    "STYLE_TYPE must be >= Style base (3500)",
+);
+
+/// Run the style checks over a slice of [`RunTypeInfo`]s.
+///
+/// Two disjoint error classes are produced:
+/// - **3501** (`STYLE_TYPE`) — run's style name is not in
+///   `spec.allowed_types` (only when the list is non-empty).
+/// - **3502** (`STYLE_PERMISSION`) — run uses a non-default style but
+///   `spec.permission == false`.
 ///
 /// # Parameters
 /// - `spec`  — the `StyleSpec` extracted from the user's DVC JSON file.
@@ -37,47 +66,73 @@ pub const STYLE_PERMISSION: u32 = ErrorCode::Style as u32 + 2;
 ///   [`crate::document::run_type::build_run_type_infos`].
 ///
 /// # Returns
-/// A `Vec<DvcErrorInfo>` — empty when `spec.permission == true` or when
-/// no run uses a custom style. Each entry's `error_code` is
-/// [`STYLE_PERMISSION`] and `use_style` is set to `true`.
+/// A `Vec<DvcErrorInfo>` — empty when both gates are satisfied.
 #[must_use]
 pub fn check(spec: &StyleSpec, runs: &[RunTypeInfo]) -> Vec<DvcErrorInfo> {
-    if spec.permission {
-        // Styles are permitted: nothing to report.
-        return Vec::new();
+    let mut errors = Vec::new();
+
+    // ── 1. Type allow-list check (JID_STYLE_TYPE = 3501) ──────────────────
+    // Only active when the spec declares a non-empty allowed_types list.
+    if let Some(allowed) = &spec.allowed_types {
+        if !allowed.is_empty() {
+            for r in runs {
+                // Build the set of allowed Korean names once per call.
+                // The list is typically short (≤ 23 entries), so a linear
+                // scan is cheaper than a HashSet for this cardinality.
+                let name_allowed = allowed
+                    .iter()
+                    .any(|t| t.as_korean_name() == r.style_name.as_str());
+                if !name_allowed {
+                    errors.push(make_error(r, STYLE_TYPE));
+                }
+            }
+        }
     }
 
-    runs.iter()
-        .filter(|r| r.is_style)
-        .map(|r| DvcErrorInfo {
-            char_pr_id_ref: r.char_pr_id_ref,
-            para_pr_id_ref: r.para_pr_id_ref,
-            text: r.text.clone(),
-            page_no: r.page_no,
-            line_no: r.line_no,
-            error_code: STYLE_PERMISSION,
-            table_id: r.table_id,
-            is_in_table: r.is_in_table,
-            is_in_table_in_table: r.is_in_table_in_table,
-            table_row: r.table_row,
-            table_col: r.table_col,
-            is_in_shape: r.is_in_shape,
-            use_hyperlink: r.is_hyperlink,
-            use_style: true,
-            error_string: crate::error::error_string(STYLE_PERMISSION, ErrorContext::default()),
-        })
-        .collect()
+    // ── 2. Permission gate (JID_STYLE_PERMISSION = 3502) ──────────────────
+    // Only active when permission == false; skips 바탕글 runs (is_style=false).
+    if !spec.permission {
+        for r in runs.iter().filter(|r| r.is_style) {
+            errors.push(make_error(r, STYLE_PERMISSION));
+        }
+    }
+
+    errors
+}
+
+/// Build a [`DvcErrorInfo`] from a run and a style error code.
+fn make_error(r: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
+    DvcErrorInfo {
+        char_pr_id_ref: r.char_pr_id_ref,
+        para_pr_id_ref: r.para_pr_id_ref,
+        text: r.text.clone(),
+        page_no: r.page_no,
+        line_no: r.line_no,
+        error_code,
+        table_id: r.table_id,
+        is_in_table: r.is_in_table,
+        is_in_table_in_table: r.is_in_table_in_table,
+        table_row: r.table_row,
+        table_col: r.table_col,
+        is_in_shape: r.is_in_shape,
+        use_hyperlink: r.is_hyperlink,
+        use_style: true,
+        error_string: crate::error::error_string(error_code, ErrorContext::default()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::document::RunTypeInfo;
-    use crate::spec::StyleSpec;
+    use crate::spec::{StyleSpec, StyleType};
 
-    fn run_with_style(is_style: bool) -> RunTypeInfo {
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn run_with_style(is_style: bool, style_name: &str) -> RunTypeInfo {
         RunTypeInfo {
             is_style,
+            style_name: style_name.into(),
             text: "테스트".into(),
             char_pr_id_ref: 1,
             para_pr_id_ref: 0,
@@ -85,10 +140,31 @@ mod tests {
         }
     }
 
+    fn default_run() -> RunTypeInfo {
+        run_with_style(false, "바탕글")
+    }
+
+    fn body_run() -> RunTypeInfo {
+        run_with_style(true, "본문")
+    }
+
+    fn custom_run() -> RunTypeInfo {
+        run_with_style(true, "커스텀스타일")
+    }
+
+    fn spec_permission_only(permission: bool) -> StyleSpec {
+        StyleSpec {
+            permission,
+            allowed_types: None,
+        }
+    }
+
+    // ── Permission-gate tests (3502) ──────────────────────────────────────────
+
     #[test]
-    fn permission_true_emits_no_errors() {
-        let spec = StyleSpec { permission: true };
-        let runs = vec![run_with_style(true), run_with_style(false)];
+    fn permission_true_emits_no_permission_errors() {
+        let spec = spec_permission_only(true);
+        let runs = vec![body_run(), default_run()];
         let errors = check(&spec, &runs);
         assert!(
             errors.is_empty(),
@@ -98,44 +174,154 @@ mod tests {
 
     #[test]
     fn permission_false_emits_error_for_styled_runs() {
-        let spec = StyleSpec { permission: false };
-        let runs = vec![
-            run_with_style(true),
-            run_with_style(false),
-            run_with_style(true),
-        ];
+        let spec = spec_permission_only(false);
+        let runs = vec![body_run(), default_run(), custom_run()];
         let errors = check(&spec, &runs);
-        assert_eq!(
-            errors.len(),
-            2,
-            "exactly two runs have is_style=true, so two errors expected"
-        );
-        for e in &errors {
-            assert_eq!(
-                e.error_code, STYLE_PERMISSION,
-                "error_code must be STYLE_PERMISSION ({})",
-                STYLE_PERMISSION
-            );
-            assert!(e.use_style, "use_style flag must be set");
+        // Two runs have is_style=true (body and custom).
+        let perm_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.error_code == STYLE_PERMISSION)
+            .collect();
+        assert_eq!(perm_errors.len(), 2, "exactly two 3502 errors expected");
+        for e in &perm_errors {
+            assert!(e.use_style, "use_style flag must be set on 3502 errors");
         }
     }
 
     #[test]
     fn permission_false_no_styled_runs_emits_no_errors() {
-        let spec = StyleSpec { permission: false };
-        let runs = vec![run_with_style(false), run_with_style(false)];
+        let spec = spec_permission_only(false);
+        let runs = vec![default_run(), default_run()];
+        let errors = check(&spec, &runs);
+        assert!(errors.is_empty(), "no styled runs → no errors");
+    }
+
+    // ── Type allow-list tests (3501) ──────────────────────────────────────────
+
+    #[test]
+    fn allowed_types_empty_emits_no_type_errors() {
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: Some(vec![]),
+        };
+        let runs = vec![body_run(), custom_run()];
         let errors = check(&spec, &runs);
         assert!(
             errors.is_empty(),
-            "no styled runs means no errors even when permission=false"
+            "empty allowed_types list must not emit any 3501 errors"
         );
     }
 
     #[test]
+    fn allowed_types_none_emits_no_type_errors() {
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: None,
+        };
+        let runs = vec![body_run(), custom_run()];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "absent allowed_types must not emit any 3501 errors"
+        );
+    }
+
+    #[test]
+    fn allowed_types_matching_run_emits_no_type_error() {
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: Some(vec![StyleType::Normal, StyleType::Body]),
+        };
+        // 바탕글 and 본문 are both in the allow-list.
+        let runs = vec![default_run(), body_run()];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.is_empty(),
+            "all runs match allowed_types → no 3501 errors"
+        );
+    }
+
+    #[test]
+    fn allowed_types_non_matching_run_emits_type_error() {
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: Some(vec![StyleType::Normal]),
+        };
+        // 바탕글 is allowed; 본문 is not.
+        let runs = vec![default_run(), body_run()];
+        let type_errors: Vec<_> = check(&spec, &runs)
+            .into_iter()
+            .filter(|e| e.error_code == STYLE_TYPE)
+            .collect();
+        assert_eq!(type_errors.len(), 1, "one 3501 error expected for 본문");
+        assert!(type_errors[0].use_style);
+    }
+
+    #[test]
+    fn custom_style_not_in_allowed_types_emits_type_error() {
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: Some(vec![StyleType::Normal, StyleType::Body]),
+        };
+        let runs = vec![custom_run()];
+        let errors = check(&spec, &runs);
+        let type_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.error_code == STYLE_TYPE)
+            .collect();
+        assert_eq!(type_errors.len(), 1, "custom style must trigger 3501");
+    }
+
+    // ── Both checks active simultaneously ────────────────────────────────────
+
+    #[test]
+    fn both_checks_fire_independently() {
+        // permission=false + allowed_types=[바탕글] means:
+        //   • 본문 run triggers 3501 (not in type list) AND 3502 (not 바탕글).
+        //   • 바탕글 run triggers neither (is_style=false, name in list).
+        let spec = StyleSpec {
+            permission: false,
+            allowed_types: Some(vec![StyleType::Normal]),
+        };
+        let runs = vec![default_run(), body_run()];
+        let errors = check(&spec, &runs);
+        let type_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.error_code == STYLE_TYPE)
+            .collect();
+        let perm_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.error_code == STYLE_PERMISSION)
+            .collect();
+        assert_eq!(type_errors.len(), 1, "one 3501 for 본문");
+        assert_eq!(perm_errors.len(), 1, "one 3502 for 본문");
+    }
+
+    #[test]
+    fn permission_true_with_allowed_types_only_3501_fires() {
+        // permission=true + allowed_types=[바탕글] means no 3502 but 3501
+        // fires for 본문.
+        let spec = StyleSpec {
+            permission: true,
+            allowed_types: Some(vec![StyleType::Normal]),
+        };
+        let runs = vec![default_run(), body_run()];
+        let errors = check(&spec, &runs);
+        assert!(
+            errors.iter().all(|e| e.error_code == STYLE_TYPE),
+            "only 3501 errors expected when permission=true"
+        );
+        assert_eq!(errors.len(), 1, "one 3501 for 본문");
+    }
+
+    // ── Error field mirror test ───────────────────────────────────────────────
+
+    #[test]
     fn error_fields_mirror_run_fields() {
-        let spec = StyleSpec { permission: false };
+        let spec = spec_permission_only(false);
         let run = RunTypeInfo {
             is_style: true,
+            style_name: "본문".into(),
             text: "스타일텍스트".into(),
             char_pr_id_ref: 7,
             para_pr_id_ref: 3,
@@ -161,9 +347,10 @@ mod tests {
         assert_eq!(e.error_code, STYLE_PERMISSION);
     }
 
+    // ── Constant range guard ──────────────────────────────────────────────────
+
     #[test]
-    fn style_permission_constant_is_in_style_range() {
-        // Guard: STYLE_PERMISSION must be in [3500, 3600).
+    fn style_constants_are_in_style_range() {
         assert!(
             STYLE_PERMISSION >= ErrorCode::Style as u32,
             "STYLE_PERMISSION must be >= Style base (3500)"
@@ -171,6 +358,14 @@ mod tests {
         assert!(
             STYLE_PERMISSION < ErrorCode::Page as u32,
             "STYLE_PERMISSION must be < next category (Page=4000)"
+        );
+        assert!(
+            STYLE_TYPE >= ErrorCode::Style as u32,
+            "STYLE_TYPE must be >= Style base (3500)"
+        );
+        assert!(
+            STYLE_TYPE < ErrorCode::Page as u32,
+            "STYLE_TYPE must be < next category (Page=4000)"
         );
     }
 }

--- a/crates/hwp-dvc-core/src/document/mod.rs
+++ b/crates/hwp-dvc-core/src/document/mod.rs
@@ -228,6 +228,12 @@ pub struct RunTypeInfo {
     pub outline_shape_id_ref: u32,
     pub is_hyperlink: bool,
     pub is_style: bool,
+    /// Korean name of the style applied to the paragraph containing this run.
+    /// Resolved from `paragraph.style_id_ref` via the header style table.
+    /// Empty string when the paragraph has no style or the style id is not
+    /// found in the header (the `is_style` flag still reflects whether the
+    /// style differs from 바탕글).
+    pub style_name: String,
 }
 
 impl Document {

--- a/crates/hwp-dvc-core/src/document/run_type/builder.rs
+++ b/crates/hwp-dvc-core/src/document/run_type/builder.rs
@@ -69,6 +69,7 @@ pub fn build_run_type_infos(header: &HeaderTables, sections: &[Section]) -> Vec<
         let ctx = SectionCtx {
             outline_shape_id_ref: section.outline_shape_id_ref,
             default_style_id: default_style,
+            header,
         };
         for paragraph in &section.paragraphs {
             walk_paragraph(&ctx, paragraph, /* cell = */ None, &mut out);
@@ -102,7 +103,7 @@ pub fn default_style_id(header: &HeaderTables) -> u32 {
 /// Section-wide context used by the walker. One per section —
 /// intentionally cheap to copy because the walker passes it by
 /// reference.
-struct SectionCtx {
+struct SectionCtx<'a> {
     /// The `outlineShapeIDRef` resolved from `<hp:secPr>` at section
     /// parse time. Mirrors the C++ reference's per-section resolution;
     /// see `RunTypeInfo::outline_shape_id_ref`.
@@ -110,6 +111,9 @@ struct SectionCtx {
     /// The style id corresponding to 바탕글. A paragraph whose
     /// `style_id_ref` equals this value is considered "unstyled".
     default_style_id: u32,
+    /// Reference to the header tables so the walker can resolve
+    /// `style_id_ref` → style name for `RunTypeInfo::style_name`.
+    header: &'a HeaderTables,
 }
 
 /// Table-cell context accumulated as the walker descends into nested
@@ -135,12 +139,22 @@ struct CellCtx {
 /// Walk one [`Paragraph`], emitting one [`RunTypeInfo`] per run and
 /// recursing into any tables owned by the paragraph.
 fn walk_paragraph(
-    ctx: &SectionCtx,
+    ctx: &SectionCtx<'_>,
     p: &Paragraph,
     cell: Option<CellCtx>,
     out: &mut Vec<RunTypeInfo>,
 ) {
     let is_style = p.style_id_ref != ctx.default_style_id;
+    // Resolve the style name once per paragraph; all runs in the paragraph
+    // share the same style. Returns an empty string when the style id is
+    // not present in the header (malformed document) — the `is_style` flag
+    // still reflects whether the style differs from 바탕글.
+    let style_name = ctx
+        .header
+        .styles
+        .get(&p.style_id_ref)
+        .map(|s| s.name.clone())
+        .unwrap_or_default();
     for run in &p.runs {
         let mut info = RunTypeInfo {
             char_pr_id_ref: run.char_pr_id_ref,
@@ -153,6 +167,7 @@ fn walk_paragraph(
             outline_shape_id_ref: ctx.outline_shape_id_ref,
             is_hyperlink: run.is_hyperlink,
             is_style,
+            style_name: style_name.clone(),
             // `is_in_shape` stays false for issue #4 (see module doc).
             is_in_shape: false,
             ..RunTypeInfo::default()
@@ -175,7 +190,7 @@ fn walk_paragraph(
 /// Walk one [`Table`], recursing into each cell's paragraphs. The
 /// table's own `nesting_depth` is used to seed `is_table_in_table`
 /// for the runs discovered inside its cells.
-fn walk_table(ctx: &SectionCtx, t: &Table, out: &mut Vec<RunTypeInfo>) {
+fn walk_table(ctx: &SectionCtx<'_>, t: &Table, out: &mut Vec<RunTypeInfo>) {
     // The reference reports the cell's enclosing table id — not the
     // outermost table. The walker naturally satisfies that because
     // it visits the cell via its direct parent table, so `t.id` here
@@ -189,7 +204,7 @@ fn walk_table(ctx: &SectionCtx, t: &Table, out: &mut Vec<RunTypeInfo>) {
 }
 
 fn walk_cell(
-    ctx: &SectionCtx,
+    ctx: &SectionCtx<'_>,
     table_id: u32,
     cell: &Cell,
     is_table_in_table: bool,
@@ -423,5 +438,44 @@ mod tests {
         // must still return a sensible u32 rather than panic.
         let h = HeaderTables::default();
         assert_eq!(default_style_id(&h), 0);
+    }
+
+    #[test]
+    fn style_name_is_populated_from_header() {
+        // Build a header with two styles: 바탕글 (id=0) and 본문 (id=1).
+        let mut h = header_with_default_style(0);
+        h.styles.insert(
+            1,
+            crate::document::header::Style {
+                id: 1,
+                style_type: "PARA".into(),
+                name: "본문".into(),
+                ..Default::default()
+            },
+        );
+        let mut s = Section::default();
+        // Paragraph using 바탕글 (id=0).
+        s.paragraphs.push(plain_paragraph(0, 0, "default"));
+        // Paragraph using 본문 (id=1).
+        s.paragraphs.push(plain_paragraph(1, 0, "body"));
+
+        let infos = build_run_type_infos(&h, &[s]);
+        assert_eq!(infos.len(), 2);
+        let default_run = infos.iter().find(|i| i.text == "default").unwrap();
+        assert_eq!(default_run.style_name, "바탕글");
+        let body_run = infos.iter().find(|i| i.text == "body").unwrap();
+        assert_eq!(body_run.style_name, "본문");
+    }
+
+    #[test]
+    fn style_name_is_empty_when_style_id_not_in_header() {
+        // A paragraph whose style_id_ref points to a non-existent entry
+        // should produce an empty style_name rather than panicking.
+        let h = header_with_default_style(0);
+        let mut s = Section::default();
+        s.paragraphs.push(plain_paragraph(99, 0, "orphan"));
+        let infos = build_run_type_infos(&h, &[s]);
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].style_name, "");
     }
 }

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -209,6 +209,21 @@ pub const BULLET_CODE: u32 = 3303;
 /// Bullet shape not in the allow-list (`JID_BULLET_SHAPES = 3304`).
 pub const BULLET_SHAPES: u32 = 3304;
 
+/// Specific error codes within the [`ErrorCode::Style`] (3500) range.
+///
+/// These mirror the `JID_STYLE_*` constants in
+/// `references/dvc/Source/JsonModel.h`.
+pub mod style_codes {
+    /// `JID_STYLE_TYPE` (3501) — the style applied to a paragraph is not in
+    /// the spec's allowed-types list. Emitted when
+    /// `StyleSpec.allowed_types` is non-empty and the run's `style_name`
+    /// does not match any entry.
+    pub const STYLE_TYPE: u32 = 3501;
+    /// `JID_STYLE_PERMISSION` (3502) — run uses a non-default style but
+    /// the spec's catch-all `permission` gate is `false`.
+    pub const STYLE_PERMISSION: u32 = 3502;
+}
+
 /// Specific error codes within the [`ErrorCode::Hyperlink`] (6900) range.
 pub mod hyperlink_codes {
     /// A run is flagged as a hyperlink but the spec forbids hyperlinks.

--- a/crates/hwp-dvc-core/src/error/messages.rs
+++ b/crates/hwp-dvc-core/src/error/messages.rs
@@ -148,6 +148,7 @@ const STATIC_MESSAGES_KO: &[(u32, &str)] = &[
     (3406, "문단 번호 수준의 번호 형식이 허용되지 않습니다"),
     (3407, "문단 번호 수준의 번호 모양이 허용되지 않습니다"),
     // ── Style (3500-range) ────────────────────────────────────────────────
+    (3501, "스타일 유형이 허용되지 않습니다"),
     (3502, "스타일 사용이 허용되지 않습니다"),
     // ── Hyperlink (6900-range) ────────────────────────────────────────────
     (6901, "하이퍼링크 사용이 허용되지 않습니다"),
@@ -249,6 +250,7 @@ const STATIC_MESSAGES_EN: &[(u32, &str)] = &[
     (3401, "paragraph numbering type is not allowed"),
     (3406, "paragraph numbering level format is not allowed"),
     (3407, "paragraph numbering level shape is not allowed"),
+    (3501, "style type is not in the allowed list"),
     (3502, "use of custom styles is not allowed"),
     (6901, "use of hyperlinks is not allowed"),
     (7001, "macro script is present but macros are not permitted"),
@@ -464,7 +466,7 @@ mod tests {
             3201, 3202, 3203, 3204, 3205, 3206, 3207, // Bullet (3300-range)
             3302, 3303, 3304, // ParaNumBullet (3400-range)
             3401, 3406, 3407, // Style (3500-range)
-            3502, // Hyperlink (6900-range)
+            3501, 3502, // Hyperlink (6900-range)
             6901, // Macro (7000-range)
             7001,
         ];
@@ -488,5 +490,15 @@ mod tests {
                 "table-detail code {code} must mention 셀 (cell): {msg}"
             );
         }
+    }
+
+    #[test]
+    fn style_type_message_is_korean() {
+        let msg = error_string(3501, ErrorContext::default());
+        assert!(!msg.is_empty(), "3501 must have a message");
+        assert!(
+            msg.chars().any(|c| c > '\u{0080}'),
+            "3501 message must contain Korean characters: {msg}"
+        );
     }
 }

--- a/crates/hwp-dvc-core/src/spec/mod.rs
+++ b/crates/hwp-dvc-core/src/spec/mod.rs
@@ -707,9 +707,151 @@ pub struct LevelType {
     pub numbershape: u32,
 }
 
+/// The logical style types defined in the HWPX format.
+///
+/// These mirror the named styles that Hancom's reference C++ DVC
+/// surfaces via `CStyle::getStyleType()` in `references/dvc/Source/`.
+/// Each variant's Korean name is the canonical `name` attribute in
+/// `<hh:style>` as written by the Hancom HWP editor.
+///
+/// The 21 variants cover the full set recognised by the reference:
+/// 바탕글, 본문, 개요1–10, 쪽번호, 머리말, 꼬리말, 각주, 미주,
+/// 메모, 차례제목, 차례1–3, 캡션.
+///
+/// The variants are ordered to match `JID_STYLE_*` in `JsonModel.h`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StyleType {
+    /// 바탕글 — default/normal body style (`StyleNormal`).
+    #[serde(rename = "바탕글")]
+    Normal,
+    /// 본문 — body text (`StyleBody`).
+    #[serde(rename = "본문")]
+    Body,
+    /// 개요 1 — outline level 1 (`StyleOutline1`).
+    #[serde(rename = "개요 1")]
+    Outline1,
+    /// 개요 2 — outline level 2 (`StyleOutline2`).
+    #[serde(rename = "개요 2")]
+    Outline2,
+    /// 개요 3 — outline level 3 (`StyleOutline3`).
+    #[serde(rename = "개요 3")]
+    Outline3,
+    /// 개요 4 — outline level 4 (`StyleOutline4`).
+    #[serde(rename = "개요 4")]
+    Outline4,
+    /// 개요 5 — outline level 5 (`StyleOutline5`).
+    #[serde(rename = "개요 5")]
+    Outline5,
+    /// 개요 6 — outline level 6 (`StyleOutline6`).
+    #[serde(rename = "개요 6")]
+    Outline6,
+    /// 개요 7 — outline level 7 (`StyleOutline7`).
+    #[serde(rename = "개요 7")]
+    Outline7,
+    /// 개요 8 — outline level 8 (`StyleOutline8`).
+    #[serde(rename = "개요 8")]
+    Outline8,
+    /// 개요 9 — outline level 9 (`StyleOutline9`).
+    #[serde(rename = "개요 9")]
+    Outline9,
+    /// 개요 10 — outline level 10 (`StyleOutline10`).
+    #[serde(rename = "개요 10")]
+    Outline10,
+    /// 쪽번호 — page number style (`StylePageNum`).
+    #[serde(rename = "쪽번호")]
+    PageNum,
+    /// 머리말 — header style (`StyleHeader`).
+    #[serde(rename = "머리말")]
+    Header,
+    /// 꼬리말 — footer style (`StyleFooter`).
+    #[serde(rename = "꼬리말")]
+    Footer,
+    /// 각주 — footnote style (`StyleFootnote`).
+    #[serde(rename = "각주")]
+    Footnote,
+    /// 미주 — endnote style (`StyleEndnote`).
+    #[serde(rename = "미주")]
+    Endnote,
+    /// 메모 — memo/comment style (`StyleMemo`).
+    #[serde(rename = "메모")]
+    Memo,
+    /// 차례 제목 — table-of-contents title style (`StyleTocTitle`).
+    #[serde(rename = "차례 제목")]
+    TocTitle,
+    /// 차례 1 — table-of-contents level 1 (`StyleToc1`).
+    #[serde(rename = "차례 1")]
+    Toc1,
+    /// 차례 2 — table-of-contents level 2 (`StyleToc2`).
+    #[serde(rename = "차례 2")]
+    Toc2,
+    /// 차례 3 — table-of-contents level 3 (`StyleToc3`).
+    #[serde(rename = "차례 3")]
+    Toc3,
+    /// 캡션 — caption style (`StyleCaption`).
+    #[serde(rename = "캡션")]
+    Caption,
+}
+
+impl StyleType {
+    /// Return the canonical Korean style name that matches the `name`
+    /// attribute of `<hh:style>` in `header.xml`.
+    ///
+    /// The mapping mirrors `CStyle::getStyleType()` in the reference C++
+    /// source (`references/dvc/Source/`).
+    #[must_use]
+    pub fn as_korean_name(&self) -> &'static str {
+        match self {
+            StyleType::Normal => "바탕글",
+            StyleType::Body => "본문",
+            StyleType::Outline1 => "개요 1",
+            StyleType::Outline2 => "개요 2",
+            StyleType::Outline3 => "개요 3",
+            StyleType::Outline4 => "개요 4",
+            StyleType::Outline5 => "개요 5",
+            StyleType::Outline6 => "개요 6",
+            StyleType::Outline7 => "개요 7",
+            StyleType::Outline8 => "개요 8",
+            StyleType::Outline9 => "개요 9",
+            StyleType::Outline10 => "개요 10",
+            StyleType::PageNum => "쪽번호",
+            StyleType::Header => "머리말",
+            StyleType::Footer => "꼬리말",
+            StyleType::Footnote => "각주",
+            StyleType::Endnote => "미주",
+            StyleType::Memo => "메모",
+            StyleType::TocTitle => "차례 제목",
+            StyleType::Toc1 => "차례 1",
+            StyleType::Toc2 => "차례 2",
+            StyleType::Toc3 => "차례 3",
+            StyleType::Caption => "캡션",
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct StyleSpec {
+    /// Catch-all gate: when `false`, every run that uses a non-default
+    /// style (any style other than 바탕글) emits error 3502
+    /// ([`crate::error::style_codes::STYLE_PERMISSION`]).
+    ///
+    /// When `true`, all custom styles are permitted — no 3502 errors
+    /// are emitted — unless `allowed_types` further restricts which
+    /// logical style types are valid.
     pub permission: bool,
+    /// Optional allow-list of logical style types (`JID_STYLE_TYPE`
+    /// / error 3501). When this list is **non-empty**, every run whose
+    /// paragraph style name does not match one of the allowed types
+    /// emits error 3501 ([`crate::error::style_codes::STYLE_TYPE`]).
+    ///
+    /// The check fires regardless of the `permission` flag — a document
+    /// may be allowed to use custom styles (`permission: true`) while
+    /// still being required to use only specific types
+    /// (`allowed_types: ["바탕글", "본문"]`).
+    ///
+    /// When this list is absent or empty, no 3501 errors are emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_types: Option<Vec<StyleType>>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -835,5 +977,62 @@ mod tests {
         assert_eq!(pnb.start_number, None);
         assert_eq!(pnb.value, None);
         assert!(pnb.leveltype.is_empty());
+    }
+
+    #[test]
+    fn style_spec_without_allowed_types_parses() {
+        let s = r#"{ "style": { "permission": false } }"#;
+        let spec = DvcSpec::from_json_str(s).unwrap();
+        let st = spec.style.unwrap();
+        assert!(!st.permission);
+        assert!(st.allowed_types.is_none());
+    }
+
+    #[test]
+    fn style_spec_with_allowed_types_parses() {
+        let s = r#"{ "style": { "permission": true, "allowed_types": ["바탕글", "본문"] } }"#;
+        let spec = DvcSpec::from_json_str(s).unwrap();
+        let st = spec.style.unwrap();
+        assert!(st.permission);
+        let types = st.allowed_types.unwrap();
+        assert_eq!(types.len(), 2);
+        assert!(types.contains(&StyleType::Normal));
+        assert!(types.contains(&StyleType::Body));
+    }
+
+    #[test]
+    fn style_type_as_korean_name_roundtrips() {
+        // Every StyleType must produce its own Korean name, and that
+        // name must round-trip through JSON deserialization.
+        let all: &[(&str, StyleType)] = &[
+            ("바탕글", StyleType::Normal),
+            ("본문", StyleType::Body),
+            ("개요 1", StyleType::Outline1),
+            ("개요 10", StyleType::Outline10),
+            ("쪽번호", StyleType::PageNum),
+            ("머리말", StyleType::Header),
+            ("꼬리말", StyleType::Footer),
+            ("각주", StyleType::Footnote),
+            ("미주", StyleType::Endnote),
+            ("메모", StyleType::Memo),
+            ("차례 제목", StyleType::TocTitle),
+            ("차례 1", StyleType::Toc1),
+            ("차례 3", StyleType::Toc3),
+            ("캡션", StyleType::Caption),
+        ];
+        for (name, variant) in all {
+            assert_eq!(variant.as_korean_name(), *name);
+            // Round-trip through JSON.
+            let json = serde_json::to_string(variant).unwrap();
+            let decoded: StyleType = serde_json::from_str(&json).unwrap();
+            assert_eq!(&decoded, variant);
+        }
+    }
+
+    #[test]
+    fn style_spec_all_21_types_parse() {
+        let json = r#"["바탕글","본문","개요 1","개요 2","개요 3","개요 4","개요 5","개요 6","개요 7","개요 8","개요 9","개요 10","쪽번호","머리말","꼬리말","각주","미주","메모","차례 제목","차례 1","차례 2","차례 3","캡션"]"#;
+        let types: Vec<StyleType> = serde_json::from_str(json).unwrap();
+        assert_eq!(types.len(), 23);
     }
 }

--- a/crates/hwp-dvc-core/tests/check_style.rs
+++ b/crates/hwp-dvc-core/tests/check_style.rs
@@ -172,3 +172,88 @@ fn style_permission_constant_in_range() {
         "STYLE_PERMISSION ({STYLE_PERMISSION}) must be < next category ({next})"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Type allow-list: allowed_types (JID_STYLE_TYPE = 3501)
+// ---------------------------------------------------------------------------
+
+use hwp_dvc_core::checker::style::STYLE_TYPE;
+
+/// When the spec allows only 바탕글 and the document uses only 바탕글,
+/// no 3501 errors should be emitted.
+#[test]
+fn style_default_only_passes_when_normal_is_in_allowed_types() {
+    let spec_json = r#"{ "style": { "permission": true, "allowed_types": ["바탕글"] } }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("spec parses");
+    let mut doc = Document::open(doc_fixture("style_default_only.hwpx")).expect("doc opens");
+    doc.parse().expect("doc parses");
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("run succeeds");
+    let type_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code == STYLE_TYPE)
+        .collect();
+    assert!(
+        type_errors.is_empty(),
+        "style_default_only must produce no 3501 errors when 바탕글 is allowed; \
+         got {type_errors:?}"
+    );
+}
+
+/// When the spec allows only 본문 and the document uses 바탕글 (not 본문),
+/// every run should emit a 3501 error because 바탕글 is not in the list.
+#[test]
+fn style_default_only_fails_when_normal_not_in_allowed_types() {
+    let spec_json = r#"{ "style": { "permission": true, "allowed_types": ["본문"] } }"#;
+    let spec = DvcSpec::from_json_str(spec_json).expect("spec parses");
+    let mut doc = Document::open(doc_fixture("style_default_only.hwpx")).expect("doc opens");
+    doc.parse().expect("doc parses");
+    let checker = Checker::new(&spec, &doc);
+    let errors = checker.run().expect("run succeeds");
+    let type_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code == STYLE_TYPE)
+        .collect();
+    assert!(
+        !type_errors.is_empty(),
+        "style_default_only must produce ≥ 1 3501 error when only 본문 is allowed"
+    );
+    for e in &type_errors {
+        assert!(e.use_style, "use_style must be true on 3501 errors");
+    }
+}
+
+/// style_custom uses a custom (non-standard) style. When permission=false
+/// and allowed_types is absent, only 3502 errors should fire (not 3501).
+#[test]
+fn style_custom_produces_only_permission_errors_when_no_allowed_types() {
+    let errors = check("style_custom.hwpx", "fixture_spec.json");
+    let (style_errors, _) = partition_style_errors(&errors);
+    assert!(
+        !style_errors.is_empty(),
+        "style_custom must emit style errors under permission=false"
+    );
+    // All style errors must be 3502, not 3501.
+    for e in &style_errors {
+        assert_eq!(
+            e.error_code, STYLE_PERMISSION,
+            "without allowed_types, only STYLE_PERMISSION (3502) should fire; got {}",
+            e.error_code
+        );
+    }
+}
+
+/// Guard that `STYLE_TYPE` is within the Style error range.
+#[test]
+fn style_type_constant_in_range() {
+    let base = ErrorCode::Style as u32;
+    let next = ErrorCode::Page as u32;
+    assert!(
+        STYLE_TYPE >= base,
+        "STYLE_TYPE ({STYLE_TYPE}) must be >= Style base ({base})"
+    );
+    assert!(
+        STYLE_TYPE < next,
+        "STYLE_TYPE ({STYLE_TYPE}) must be < next category ({next})"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `StyleType` enum (23 variants: 바탕글 through 캡션) to `spec/mod.rs` with serde rename attributes and `as_korean_name()` helper, mirroring `CStyle::getStyleType()` from the reference C++.
- Extend `StyleSpec` with `allowed_types: Option<Vec<StyleType>>`; when non-empty, every run whose paragraph style name is not in the list emits error 3501 (`STYLE_TYPE`), independently of the `permission` flag.
- Add `error::style_codes` module with `STYLE_TYPE = 3501` and `STYLE_PERMISSION = 3502`; re-export both from `checker::style` (backward-compatible — existing callers of `checker::style::STYLE_PERMISSION` are unaffected).
- Populate `RunTypeInfo::style_name` in the builder by resolving `paragraph.style_id_ref` through the header style table.
- Add Korean (`스타일 유형이 허용되지 않습니다`) and English messages for error code 3501.

## Test plan

- [x] Unit tests in `checker/style/mod.rs`: permission gate (3502), type allow-list (3501), and both checks firing simultaneously.
- [x] Unit tests in `spec/mod.rs`: `StyleType` JSON round-trip, all 23 variants parse, `StyleSpec` with/without `allowed_types`.
- [x] Unit tests in `document/run_type/builder.rs`: `style_name` populated correctly; empty when style id not in header.
- [x] Integration tests in `tests/check_style.rs`: `style_default_only` passes when 바탕글 is in allowed list; fails when only 본문 is allowed; `style_custom` produces only 3502 errors when `allowed_types` is absent.
- [x] `cargo build --workspace`, `cargo test --workspace`, `cargo test --workspace --features xml`, `cargo clippy --workspace --all-targets -- -D warnings` all pass.

Closes #47. Part of #38.