### PR TITLE
feat: extend CharShape validator to full JID_CHAR_SHAPE_* coverage

### DIFF
--- a/crates/hwp-dvc-cli/src/main.rs
+++ b/crates/hwp-dvc-cli/src/main.rs
@@ -144,7 +144,11 @@ fn main() -> Result<()> {
         .parse()
         .with_context(|| format!("failed to parse HWPX: {}", cli.hwpx.display()))?;
 
-    let level = if cli.simple { CheckLevel::Simple } else { CheckLevel::All };
+    let level = if cli.simple {
+        CheckLevel::Simple
+    } else {
+        CheckLevel::All
+    };
     let scope = OutputScope {
         all: cli.all_option,
         table: cli.table,
@@ -153,7 +157,12 @@ fn main() -> Result<()> {
         style: cli.style,
         hyperlink: cli.hyperlink,
     };
-    let checker = Checker { spec: &spec, document: &document, level, scope };
+    let checker = Checker {
+        spec: &spec,
+        document: &document,
+        level,
+        scope,
+    };
 
     let errors = checker.run().context("validation run failed")?;
 

--- a/crates/hwp-dvc-core/src/checker/char_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/char_shape/mod.rs
@@ -15,17 +15,47 @@
 //!
 //! # Error codes
 //!
-//! The four codes exposed by this issue are:
-//!
-//! | Constant               | Value | `JID_*` reference            |
-//! |------------------------|-------|------------------------------|
-//! | `CHARSHAPE_LANGTYPE`   | 1003  | `JID_CHAR_SHAPE_LANG`        |
-//! | `CHARSHAPE_FONT`       | 1004  | `JID_CHAR_SHAPE_FONT`        |
-//! | `CHARSHAPE_RATIO`      | 1007  | `JID_CHAR_SHAPE_RATIO`       |
-//! | `CHARSHAPE_SPACING`    | 1008  | `JID_CHAR_SHAPE_SPACING`     |
-//!
-//! Additional spec fields (bold, italic, shadow, …) are TODO-annotated
-//! below with the matching `JID_CHAR_SHAPE_*` constant.
+//! | Constant                       | Value | `JID_*` reference                  |
+//! |--------------------------------|-------|------------------------------------|
+//! | `CHARSHAPE_FONTSIZE`           | 1001  | `JID_CHAR_SHAPE_FONTSIZE`          |
+//! | `CHARSHAPE_LANGSET`            | 1002  | `JID_CHAR_SHAPE_LANGSET`           |
+//! | `CHARSHAPE_LANGTYPE`           | 1003  | `JID_CHAR_SHAPE_LANG`              |
+//! | `CHARSHAPE_FONT`               | 1004  | `JID_CHAR_SHAPE_FONT`              |
+//! | `CHARSHAPE_RSIZE`              | 1005  | `JID_CHAR_SHAPE_RSIZE`             |
+//! | `CHARSHAPE_POSITION`           | 1006  | `JID_CHAR_SHAPE_POSITION`          |
+//! | `CHARSHAPE_RATIO`              | 1007  | `JID_CHAR_SHAPE_RATIO`             |
+//! | `CHARSHAPE_SPACING`            | 1008  | `JID_CHAR_SHAPE_SPACING`           |
+//! | `CHARSHAPE_BOLD`               | 1009  | `JID_CHAR_SHAPE_BOLD`              |
+//! | `CHARSHAPE_ITALIC`             | 1010  | `JID_CHAR_SHAPE_ITALIC`            |
+//! | `CHARSHAPE_UNDERLINE`          | 1011  | `JID_CHAR_SHAPE_UNDERLINE`         |
+//! | `CHARSHAPE_STRIKEOUT`          | 1012  | `JID_CHAR_SHAPE_STRIKEOUT`         |
+//! | `CHARSHAPE_OUTLINE`            | 1013  | `JID_CHAR_SHAPE_OUTLINE`           |
+//! | `CHARSHAPE_EMBOSS`             | 1014  | `JID_CHAR_SHAPE_EMBOSS`            |
+//! | `CHARSHAPE_ENGRAVE`            | 1015  | `JID_CHAR_SHAPE_ENGRAVE`           |
+//! | `CHARSHAPE_SHADOW`             | 1016  | `JID_CHAR_SHAPE_SHADOW`            |
+//! | `CHARSHAPE_SUPSCRIPT`          | 1017  | `JID_CHAR_SHAPE_SUPSCRIPT`         |
+//! | `CHARSHAPE_SUBSCRIPT`          | 1018  | `JID_CHAR_SHAPE_SUBSCRIPT`         |
+//! | `CHARSHAPE_SHADOWTYPE`         | 1019  | `JID_CHAR_SHAPE_SHADOWTYPE`        |
+//! | `CHARSHAPE_SHADOW_X`           | 1020  | `JID_CHAR_SHAPE_SHADOW_X`          |
+//! | `CHARSHAPE_SHADOW_Y`           | 1021  | `JID_CHAR_SHAPE_SHADOW_Y`          |
+//! | `CHARSHAPE_SHADOW_COLOR`       | 1022  | `JID_CHAR_SHAPE_SHADOW_COLOR`      |
+//! | `CHARSHAPE_UNDERLINE_POSITION` | 1023  | `JID_CHAR_SHAPE_UNDERLINE_POSITION`|
+//! | `CHARSHAPE_UNDERLINE_SHAPE`    | 1024  | `JID_CHAR_SHAPE_UNDERLINE_SHAPE`   |
+//! | `CHARSHAPE_UNDERLINE_COLOR`    | 1025  | `JID_CHAR_SHAPE_UNDERLINE_COLOR`   |
+//! | `CHARSHAPE_STRIKEOUT_SHAPE`    | 1026  | `JID_CHAR_SHAPE_STRIKEOUT_SHAPE`   |
+//! | `CHARSHAPE_STRIKEOUT_COLOR`    | 1027  | `JID_CHAR_SHAPE_STRIKEOUT_COLOR`   |
+//! | `CHARSHAPE_OUTLINETYPE`        | 1028  | `JID_CHAR_SHAPE_OUTLINETYPE`       |
+//! | `CHARSHAPE_EMPTYSPACE`         | 1029  | `JID_CHAR_SHAPE_EMPTYSPACE`        |
+//! | `CHARSHAPE_POINT`              | 1030  | `JID_CHAR_SHAPE_POINT`             |
+//! | `CHARSHAPE_KERNING`            | 1031  | `JID_CHAR_SHAPE_KERNING`           |
+//! | `CHARSHAPE_BG_BORDER`          | 1032  | `JID_CHAR_SHAPE_BG_BORDER`         |
+//! | `CHARSHAPE_BG_BORDER_POSITION` | 1033  | `JID_CHAR_SHAPE_BG_BORDER_POSITION`|
+//! | `CHARSHAPE_BG_BORDER_BORDERTYPE`| 1034 | `JID_CHAR_SHAPE_BG_BORDER_BORDERTYPE`|
+//! | `CHARSHAPE_BG_BORDER_SIZE`     | 1035  | `JID_CHAR_SHAPE_BG_BORDER_SIZE`    |
+//! | `CHARSHAPE_BG_BORDER_COLOR`    | 1036  | `JID_CHAR_SHAPE_BG_BORDER_COLOR`   |
+//! | `CHARSHAPE_BG_COLOR`           | 1037  | `JID_CHAR_SHAPE_BG_COLOR`          |
+//! | `CHARSHAPE_BG_PATTONCOLOR`     | 1038  | `JID_CHAR_SHAPE_BG_PATTONCOLOR`    |
+//! | `CHARSHAPE_BG_PATTONTYPE`      | 1039  | `JID_CHAR_SHAPE_BG_PATTONTYPE`     |
 
 use crate::checker::{CheckLevel, DvcErrorInfo};
 use crate::document::header::{CharShape, FontFace, HeaderTables};
@@ -38,41 +68,18 @@ use crate::spec::CharShapeSpec;
 // (base 1000 = JID_CHAR_SHAPE per references/dvc/Source/JsonModel.h).
 // ──────────────────────────────────────────────────────────────────────────────
 
-/// Error code for a lang-type mismatch (`JID_CHAR_SHAPE_LANG = 1003`).
-pub const CHARSHAPE_LANGTYPE: u32 = 1003;
-
-/// Error code for a font-name not in the allow-list (`JID_CHAR_SHAPE_FONT = 1004`).
-pub const CHARSHAPE_FONT: u32 = 1004;
-
-/// Error code for a ratio value outside the allowed range
-/// (`JID_CHAR_SHAPE_RATIO = 1007`).
-pub const CHARSHAPE_RATIO: u32 = 1007;
-
-/// Error code for a spacing value outside the allowed range
-/// (`JID_CHAR_SHAPE_SPACING = 1008`).
-pub const CHARSHAPE_SPACING: u32 = 1008;
-
-// TODO: JID_CHAR_SHAPE_FONTSIZE = 1001 — font size range check
-// TODO: JID_CHAR_SHAPE_LANGSET  = 1002 — langset object validation
-// TODO: JID_CHAR_SHAPE_RSIZE    = 1005 — relative size range check
-// TODO: JID_CHAR_SHAPE_POSITION = 1006 — character position check
-// TODO: JID_CHAR_SHAPE_BOLD     = 1009 — bold flag check
-// TODO: JID_CHAR_SHAPE_ITALIC   = 1010 — italic flag check
-// TODO: JID_CHAR_SHAPE_UNDERLINE = 1011 — underline flag check
-// TODO: JID_CHAR_SHAPE_STRIKEOUT = 1012 — strikeout flag check
-// TODO: JID_CHAR_SHAPE_OUTLINE  = 1013 — outline flag check
-// TODO: JID_CHAR_SHAPE_EMBOSS   = 1014 — emboss flag check
-// TODO: JID_CHAR_SHAPE_ENGRAVE  = 1015 — engrave flag check
-// TODO: JID_CHAR_SHAPE_SHADOW   = 1016 — shadow flag check
-// TODO: JID_CHAR_SHAPE_SUPSCRIPT = 1017 — superscript flag check
-// TODO: JID_CHAR_SHAPE_SUBSCRIPT = 1018 — subscript flag check
-// TODO: JID_CHAR_SHAPE_SHADOWTYPE = 1019 — shadow type check
-// TODO: JID_CHAR_SHAPE_SHADOW_X  = 1020 — shadow X direction check
-// TODO: JID_CHAR_SHAPE_SHADOW_Y  = 1021 — shadow Y direction check
-// TODO: JID_CHAR_SHAPE_SHADOW_COLOR = 1022 — shadow color check
-// TODO: JID_CHAR_SHAPE_KERNING   = 1031 — kerning flag check
-// TODO: JID_CHAR_SHAPE_BG_BORDER = 1032 — background border check
-// TODO: JID_CHAR_SHAPE_BG_COLOR  = 1037 — background color check
+pub use crate::error::{
+    CHARSHAPE_BG_BORDER, CHARSHAPE_BG_BORDER_BORDERTYPE, CHARSHAPE_BG_BORDER_COLOR,
+    CHARSHAPE_BG_BORDER_POSITION, CHARSHAPE_BG_BORDER_SIZE, CHARSHAPE_BG_COLOR,
+    CHARSHAPE_BG_PATTONCOLOR, CHARSHAPE_BG_PATTONTYPE, CHARSHAPE_BOLD, CHARSHAPE_EMBOSS,
+    CHARSHAPE_EMPTYSPACE, CHARSHAPE_ENGRAVE, CHARSHAPE_FONT, CHARSHAPE_FONTSIZE, CHARSHAPE_ITALIC,
+    CHARSHAPE_KERNING, CHARSHAPE_LANGSET, CHARSHAPE_LANGTYPE, CHARSHAPE_OUTLINE,
+    CHARSHAPE_OUTLINETYPE, CHARSHAPE_POINT, CHARSHAPE_POSITION, CHARSHAPE_RATIO, CHARSHAPE_RSIZE,
+    CHARSHAPE_SHADOW, CHARSHAPE_SHADOWTYPE, CHARSHAPE_SHADOW_COLOR, CHARSHAPE_SHADOW_X,
+    CHARSHAPE_SHADOW_Y, CHARSHAPE_SPACING, CHARSHAPE_STRIKEOUT, CHARSHAPE_STRIKEOUT_COLOR,
+    CHARSHAPE_STRIKEOUT_SHAPE, CHARSHAPE_SUBSCRIPT, CHARSHAPE_SUPSCRIPT, CHARSHAPE_UNDERLINE,
+    CHARSHAPE_UNDERLINE_COLOR, CHARSHAPE_UNDERLINE_POSITION, CHARSHAPE_UNDERLINE_SHAPE,
+};
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Internal intermediate record
@@ -175,6 +182,32 @@ fn check_char_shape_to_check_list(
     font_faces: &[FontFace],
     errors: &mut Vec<ErrorInfo>,
 ) {
+    // JID_CHAR_SHAPE_FONTSIZE (1001) — font size in 0.1pt units.
+    //
+    // `CharShape.height` stores the font size in 0.1pt units. Compared
+    // against the spec's `fontsize` integer for an exact match.
+    if let Some(spec_fontsize) = spec.fontsize {
+        if cs.height != spec_fontsize {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_FONTSIZE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_LANGSET (1002) — per-language slot validation.
+    //
+    // The langset check in the reference validates that each document charshape
+    // uses a lang slot matching the spec-supplied langset object. Full per-slot
+    // validation requires the document-side `LangType` decoding which is deferred
+    // to a later issue (see TODO below). The constant is registered and wired
+    // to a stub so downstream code referencing CHARSHAPE_LANGSET compiles cleanly.
+    //
+    // TODO(#9): implement full langset slot validation once CharShape carries
+    // the resolved LangType per slot. Error code: CHARSHAPE_LANGSET (1002).
+    let _ = spec.langtype.as_ref(); // Used below in the langtype check
+
     // JID_CHAR_SHAPE_LANG (1003) — langtype check.
     //
     // The reference stores langtype as a raw integer (LangType enum).
@@ -188,7 +221,7 @@ fn check_char_shape_to_check_list(
     // matches the reference behaviour of flagging the charshape when the
     // field is active but cannot be verified.
     //
-    // TODO: decode the hangul/latin/… langtype from CharShape once the
+    // TODO(#9): decode the hangul/latin/… langtype from CharShape once the
     // header parser exposes it (issue #2 addendum).
     if let Some(ref _langtype) = spec.langtype {
         // langtype verification requires the document-side lang enum which is
@@ -218,6 +251,36 @@ fn check_char_shape_to_check_list(
                 char_pr_id: cs.id,
                 error_code: CHARSHAPE_FONT,
                 font_name,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_RSIZE (1005) — relative size range check.
+    //
+    // `CharShape.rel_sz` stores relative size per language slot (percentage).
+    // We check the Hangul slot (index 0) for an exact match with the spec.
+    if let Some(spec_rsize) = spec.rsize {
+        let doc_rsize = cs.rel_sz.values[0]; // Hangul slot
+        if doc_rsize != spec_rsize {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_RSIZE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_POSITION (1006) — character position check.
+    //
+    // `CharShape.offset` stores vertical position per language slot (in 0.1pt units).
+    // We check the Hangul slot (index 0) for an exact match with the spec.
+    if let Some(spec_position) = spec.position {
+        let doc_position = cs.offset.values[0]; // Hangul slot
+        if doc_position != spec_position {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_POSITION,
+                font_name: None,
             });
         }
     }
@@ -254,6 +317,233 @@ fn check_char_shape_to_check_list(
             });
         }
     }
+
+    // JID_CHAR_SHAPE_BOLD (1009) — bold flag check.
+    if let Some(spec_bold) = spec.bold {
+        if cs.bold != spec_bold {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_BOLD,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_ITALIC (1010) — italic flag check.
+    if let Some(spec_italic) = spec.italic {
+        if cs.italic != spec_italic {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_ITALIC,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_UNDERLINE (1011) — underline flag check.
+    if let Some(spec_underline) = spec.underline {
+        if cs.underline != spec_underline {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_UNDERLINE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_STRIKEOUT (1012) — strikeout flag check.
+    if let Some(spec_strikeout) = spec.strikeout {
+        if cs.strikeout != spec_strikeout {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_STRIKEOUT,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_OUTLINE (1013) — outline flag check.
+    if let Some(spec_outline) = spec.outline {
+        if cs.outline != spec_outline {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_OUTLINE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_EMBOSS (1014) — emboss flag check.
+    if let Some(spec_emboss) = spec.emboss {
+        if cs.emboss != spec_emboss {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_EMBOSS,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_ENGRAVE (1015) — engrave flag check.
+    if let Some(spec_engrave) = spec.engrave {
+        if cs.engrave != spec_engrave {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_ENGRAVE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_SHADOW (1016) — shadow flag check.
+    if let Some(spec_shadow) = spec.shadow {
+        if cs.shadow != spec_shadow {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_SHADOW,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_SUPSCRIPT (1017) — superscript flag check.
+    if let Some(spec_supscript) = spec.supscript {
+        if cs.supscript != spec_supscript {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_SUPSCRIPT,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_SUBSCRIPT (1018) — subscript flag check.
+    if let Some(spec_subscript) = spec.subscript {
+        if cs.subscript != spec_subscript {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_SUBSCRIPT,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_SHADOWTYPE (1019) — shadow type check.
+    //
+    // The document stores the shadow type as the "type" attribute of the
+    // `<hh:shadow>` element. The CharShape bool `shadow` indicates active/inactive
+    // but the detailed type string is not yet parsed into a dedicated field.
+    //
+    // TODO: extend CharShape to carry shadow_type: String once the header parser
+    // is extended to preserve the type attribute. Error code: CHARSHAPE_SHADOWTYPE (1019).
+
+    // JID_CHAR_SHAPE_SHADOW_X (1020), JID_CHAR_SHAPE_SHADOW_Y (1021),
+    // JID_CHAR_SHAPE_SHADOW_COLOR (1022) — shadow detail checks.
+    //
+    // These sub-fields (offsetX, offsetY, color from `<hh:shadow>`) require
+    // CharShape to carry dedicated shadow_offset_x, shadow_offset_y, shadow_color
+    // fields that are not yet decoded by the header parser.
+    //
+    // TODO: extend CharShape and the header parser to carry shadow detail attrs.
+    // Error codes: CHARSHAPE_SHADOW_X (1020), CHARSHAPE_SHADOW_Y (1021),
+    //              CHARSHAPE_SHADOW_COLOR (1022).
+
+    // JID_CHAR_SHAPE_UNDERLINE_POSITION (1023), _SHAPE (1024), _COLOR (1025)
+    // JID_CHAR_SHAPE_STRIKEOUT_SHAPE (1026), _COLOR (1027)
+    // JID_CHAR_SHAPE_OUTLINETYPE (1028)
+    //
+    // These sub-fields require the header parser to store the shape/type/color
+    // attributes from the `<hh:underline>`, `<hh:strikeout>`, and `<hh:outline>`
+    // child elements. The current CharShape only carries the boolean presence flags.
+    //
+    // TODO: extend CharShape to carry underline_position, underline_shape,
+    // underline_color, strikeout_shape, strikeout_color, outline_type.
+    // Error codes: 1023–1028.
+
+    // JID_CHAR_SHAPE_EMPTYSPACE (1029) — empty-space flag.
+    //
+    // Corresponds to `useFontSpace` attribute on `<hh:charPr>`.
+    if let Some(spec_emptyspace) = spec.emptyspace {
+        if cs.use_font_space != spec_emptyspace {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_EMPTYSPACE,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_POINT (1030) — font size in points.
+    //
+    // The reference stores font size as both raw HWPUNIT (height) and as a
+    // floating-point point value. We derive the point value from `height`:
+    // HWPX stores height in 1/100pt units, so `point = height / 100.0`.
+    // (e.g. height=1000 → 10pt, height=1200 → 12pt)
+    if let Some(spec_point) = spec.point {
+        let doc_point = cs.height as f64 / 100.0;
+        // Use a small epsilon for float comparison (0.05 pt tolerance).
+        if (doc_point - spec_point).abs() > 0.05 {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_POINT,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_KERNING (1031) — kerning flag.
+    //
+    // Corresponds to `useKerning` attribute on `<hh:charPr>`.
+    if let Some(spec_kerning) = spec.kerning {
+        if cs.use_kerning != spec_kerning {
+            errors.push(ErrorInfo {
+                char_pr_id: cs.id,
+                error_code: CHARSHAPE_KERNING,
+                font_name: None,
+            });
+        }
+    }
+
+    // JID_CHAR_SHAPE_BG_BORDER (1032) through JID_CHAR_SHAPE_BG_BORDER_COLOR (1036)
+    //
+    // The CharShape carries `border_fill_id_ref` which references a BorderFill
+    // entry in the header. The `tables` parameter only exposes `char_shapes` and
+    // `font_faces` in the current function signature; border-fill lookups require
+    // the full `HeaderTables`. For the extended border check we do a conservative
+    // presence check: if the spec supplies a border object and the charshape's
+    // borderFillIDRef is 0 (= no border), emit a BG_BORDER error. More granular
+    // sub-checks (position, type, size, color) are deferred until HeaderTables is
+    // threaded through this function path.
+    //
+    // TODO: thread `&HeaderTables` through to enable full border sub-field checks
+    // (1033–1036). Error codes: CHARSHAPE_BG_BORDER_POSITION (1033),
+    // CHARSHAPE_BG_BORDER_BORDERTYPE (1034), CHARSHAPE_BG_BORDER_SIZE (1035),
+    // CHARSHAPE_BG_BORDER_COLOR (1036).
+    if spec.border.is_some() && cs.border_fill_id_ref == 0 {
+        errors.push(ErrorInfo {
+            char_pr_id: cs.id,
+            error_code: CHARSHAPE_BG_BORDER,
+            font_name: None,
+        });
+    }
+
+    // JID_CHAR_SHAPE_BG_COLOR (1037) — background fill color.
+    //
+    // The background color is part of the BorderFill record (via `border_fill_id_ref`),
+    // not directly on CharShape. Detailed fill-color comparison requires looking up
+    // the BorderFill in HeaderTables and comparing its fill brush color.
+    //
+    // TODO: look up BorderFill from HeaderTables and compare fill color against
+    // spec.bg_color. Error code: CHARSHAPE_BG_COLOR (1037).
+
+    // JID_CHAR_SHAPE_BG_PATTONCOLOR (1038), JID_CHAR_SHAPE_BG_PATTONTYPE (1039)
+    //
+    // Background pattern color and type live inside the `<hc:fillBrush>` subtree
+    // of the referenced `<hh:borderFill>`. These are not decoded by the current
+    // border fill parser.
+    //
+    // TODO: extend BorderFill to carry fill-brush pattern color/type.
+    // Error codes: CHARSHAPE_BG_PATTONCOLOR (1038), CHARSHAPE_BG_PATTONTYPE (1039).
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -334,7 +624,7 @@ mod tests {
             font: vec!["함초롬바탕".to_string(), "함초롬돋움".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -355,7 +645,7 @@ mod tests {
             font: vec!["함초롬바탕".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -372,12 +662,7 @@ mod tests {
         let tables = make_tables_with(cs, font_faces);
         let runs = vec![make_run(0)];
 
-        let spec = CharShapeSpec {
-            font: vec![],
-            ratio: None,
-            spacing: None,
-            langtype: None,
-        };
+        let spec = CharShapeSpec::default();
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
         assert!(
@@ -399,7 +684,7 @@ mod tests {
             font: vec!["함초롬바탕".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -424,7 +709,7 @@ mod tests {
             font: vec!["함초롬바탕".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -447,7 +732,7 @@ mod tests {
             font: vec!["함초롬바탕".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -472,13 +757,427 @@ mod tests {
             font: vec!["함초롬바탕".to_string()],
             ratio: Some(100),
             spacing: Some(0),
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
         assert!(
             errors.iter().any(|e| e.error_code == CHARSHAPE_SPACING),
             "expected CHARSHAPE_SPACING error; got: {errors:?}"
+        );
+    }
+
+    // ── fontsize ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fontsize_match_produces_no_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.height = 1000; // 10pt in 0.1pt units
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            fontsize: Some(1000),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().all(|e| e.error_code != CHARSHAPE_FONTSIZE),
+            "no CHARSHAPE_FONTSIZE error expected; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fontsize_mismatch_produces_fontsize_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.height = 1200; // 12pt, spec wants 10pt
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            fontsize: Some(1000), // 10pt
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_FONTSIZE),
+            "expected CHARSHAPE_FONTSIZE error; got: {errors:?}"
+        );
+    }
+
+    // ── bold ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn bold_match_produces_no_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.bold = false;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            bold: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().all(|e| e.error_code != CHARSHAPE_BOLD),
+            "no CHARSHAPE_BOLD error expected; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn bold_mismatch_produces_bold_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.bold = true; // doc is bold, spec wants false
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            bold: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_BOLD),
+            "expected CHARSHAPE_BOLD error; got: {errors:?}"
+        );
+    }
+
+    // ── italic ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn italic_mismatch_produces_italic_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.italic = true; // doc is italic, spec wants false
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            italic: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_ITALIC),
+            "expected CHARSHAPE_ITALIC error; got: {errors:?}"
+        );
+    }
+
+    // ── underline ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn underline_mismatch_produces_underline_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.underline = true; // doc has underline, spec wants false
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            underline: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_UNDERLINE),
+            "expected CHARSHAPE_UNDERLINE error; got: {errors:?}"
+        );
+    }
+
+    // ── strikeout ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn strikeout_mismatch_produces_strikeout_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.strikeout = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            strikeout: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_STRIKEOUT),
+            "expected CHARSHAPE_STRIKEOUT error; got: {errors:?}"
+        );
+    }
+
+    // ── outline ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn outline_mismatch_produces_outline_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.outline = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            outline: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_OUTLINE),
+            "expected CHARSHAPE_OUTLINE error; got: {errors:?}"
+        );
+    }
+
+    // ── emboss ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn emboss_mismatch_produces_emboss_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.emboss = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            emboss: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_EMBOSS),
+            "expected CHARSHAPE_EMBOSS error; got: {errors:?}"
+        );
+    }
+
+    // ── engrave ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn engrave_mismatch_produces_engrave_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.engrave = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            engrave: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_ENGRAVE),
+            "expected CHARSHAPE_ENGRAVE error; got: {errors:?}"
+        );
+    }
+
+    // ── shadow ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn shadow_mismatch_produces_shadow_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.shadow = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            shadow: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_SHADOW),
+            "expected CHARSHAPE_SHADOW error; got: {errors:?}"
+        );
+    }
+
+    // ── supscript / subscript ──────────────────────────────────────────────────
+
+    #[test]
+    fn supscript_mismatch_produces_supscript_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.supscript = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            supscript: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_SUPSCRIPT),
+            "expected CHARSHAPE_SUPSCRIPT error; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_mismatch_produces_subscript_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.subscript = true;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            subscript: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_SUBSCRIPT),
+            "expected CHARSHAPE_SUBSCRIPT error; got: {errors:?}"
+        );
+    }
+
+    // ── rsize ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn rsize_mismatch_produces_rsize_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        let mut rel_sz = LangTuple::<u32>::default();
+        rel_sz.set(FontLang::Hangul, 80); // 80%, spec wants 100%
+        cs.rel_sz = rel_sz;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            rsize: Some(100),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_RSIZE),
+            "expected CHARSHAPE_RSIZE error; got: {errors:?}"
+        );
+    }
+
+    // ── position ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn position_mismatch_produces_position_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        let mut offset = LangTuple::<i32>::default();
+        offset.set(FontLang::Hangul, 5); // offset = 5, spec wants 0
+        cs.offset = offset;
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            position: Some(0),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_POSITION),
+            "expected CHARSHAPE_POSITION error; got: {errors:?}"
+        );
+    }
+
+    // ── emptyspace ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn emptyspace_mismatch_produces_emptyspace_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.use_font_space = true; // doc uses font space, spec wants false
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            emptyspace: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_EMPTYSPACE),
+            "expected CHARSHAPE_EMPTYSPACE error; got: {errors:?}"
+        );
+    }
+
+    // ── point ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn point_match_produces_no_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.height = 1000; // 10pt
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            point: Some(10.0),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().all(|e| e.error_code != CHARSHAPE_POINT),
+            "no CHARSHAPE_POINT error expected; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn point_mismatch_produces_point_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.height = 1200; // 12pt, spec wants 10pt
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            point: Some(10.0),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_POINT),
+            "expected CHARSHAPE_POINT error; got: {errors:?}"
+        );
+    }
+
+    // ── kerning ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn kerning_mismatch_produces_kerning_error() {
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.use_kerning = true; // doc has kerning, spec wants false
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            kerning: Some(false),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_KERNING),
+            "expected CHARSHAPE_KERNING error; got: {errors:?}"
         );
     }
 
@@ -494,9 +1193,7 @@ mod tests {
 
         let spec = CharShapeSpec {
             font: vec!["함초롬바탕".to_string()],
-            ratio: None,
-            spacing: None,
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::Simple);
@@ -517,9 +1214,7 @@ mod tests {
 
         let spec = CharShapeSpec {
             font: vec!["함초롬바탕".to_string()],
-            ratio: None,
-            spacing: None,
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -551,9 +1246,7 @@ mod tests {
 
         let spec = CharShapeSpec {
             font: vec!["함초롬바탕".to_string()],
-            ratio: None,
-            spacing: None,
-            langtype: None,
+            ..Default::default()
         };
 
         let errors = check(&spec, &tables, &runs, CheckLevel::All);
@@ -569,6 +1262,60 @@ mod tests {
         assert!(
             e.error_code >= 1000 && e.error_code < 2000,
             "error code must be in CharShape range"
+        );
+    }
+
+    // ── bg_border presence check ───────────────────────────────────────────────
+
+    #[test]
+    fn bg_border_absent_when_spec_requires_produces_error() {
+        use crate::spec::CharShapeBorderSpec;
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.border_fill_id_ref = 0; // no border fill referenced
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            border: Some(CharShapeBorderSpec {
+                position: Some(1),
+                bordertype: Some(1),
+                size: Some(0.12),
+                color: Some("#000000".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().any(|e| e.error_code == CHARSHAPE_BG_BORDER),
+            "expected CHARSHAPE_BG_BORDER error when border_fill_id_ref=0; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn bg_border_present_with_spec_does_not_produce_error() {
+        use crate::spec::CharShapeBorderSpec;
+        let font_faces = make_font_faces(&[(1, "함초롬바탕")]);
+        let mut cs = make_char_shape(0, 1, 100, 0);
+        cs.border_fill_id_ref = 1; // border fill is referenced
+        let tables = make_tables_with(cs, font_faces);
+        let runs = vec![make_run(0)];
+
+        let spec = CharShapeSpec {
+            border: Some(CharShapeBorderSpec {
+                position: Some(1),
+                bordertype: Some(1),
+                size: Some(0.12),
+                color: Some("#000000".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let errors = check(&spec, &tables, &runs, CheckLevel::All);
+        assert!(
+            errors.iter().all(|e| e.error_code != CHARSHAPE_BG_BORDER),
+            "no CHARSHAPE_BG_BORDER error expected when border_fill present; got: {errors:?}"
         );
     }
 }

--- a/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/hyperlink/mod.rs
@@ -9,7 +9,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::RunTypeInfo;
-use crate::error::{ErrorContext, ErrorCode};
+use crate::error::{ErrorCode, ErrorContext};
 use crate::spec::HyperlinkSpec;
 
 /// Error code for a forbidden hyperlink run.

--- a/crates/hwp-dvc-core/src/checker/macro_/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/macro_/mod.rs
@@ -29,7 +29,10 @@ pub fn check(spec: &MacroSpec, document: &Document) -> Vec<DvcErrorInfo> {
 
     let error = DvcErrorInfo {
         error_code: macro_codes::MACRO_PERMISSION,
-        error_string: crate::error::error_string(macro_codes::MACRO_PERMISSION, ErrorContext::default()),
+        error_string: crate::error::error_string(
+            macro_codes::MACRO_PERMISSION,
+            ErrorContext::default(),
+        ),
         ..DvcErrorInfo::default()
     };
     vec![error]

--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -80,7 +80,12 @@ impl OutputScope {
     /// emitted.
     #[inline]
     fn is_default(&self) -> bool {
-        !self.all && !self.table && !self.table_detail && !self.shape && !self.style && !self.hyperlink
+        !self.all
+            && !self.table
+            && !self.table_detail
+            && !self.shape
+            && !self.style
+            && !self.hyperlink
     }
 
     /// Returns `true` when this category should be included in the output.

--- a/crates/hwp-dvc-core/src/checker/style/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/style/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::checker::DvcErrorInfo;
 use crate::document::RunTypeInfo;
-use crate::error::{ErrorContext, ErrorCode};
+use crate::error::{ErrorCode, ErrorContext};
 use crate::spec::StyleSpec;
 
 /// Concrete error code emitted when a run uses a non-default style and

--- a/crates/hwp-dvc-core/src/error.rs
+++ b/crates/hwp-dvc-core/src/error.rs
@@ -110,17 +110,122 @@ pub const SPECIALCHAR_MAX: u32 = 3102;
 // CharShape-range error code constants (mirrors JsonModel.h JID_CHAR_SHAPE_*)
 // ──────────────────────────────────────────────────────────────────────────────
 
+/// Font size outside the allowed range (`JID_CHAR_SHAPE_FONTSIZE = JID_CHAR_SHAPE + 1`).
+pub const CHARSHAPE_FONTSIZE: u32 = 1001;
+
+/// LangSet slot validation failure (`JID_CHAR_SHAPE_LANGSET = JID_CHAR_SHAPE + 2`).
+pub const CHARSHAPE_LANGSET: u32 = 1002;
+
 /// Lang-type mismatch (`JID_CHAR_SHAPE_LANG = JID_CHAR_SHAPE + 3`).
 pub const CHARSHAPE_LANGTYPE: u32 = 1003;
 
 /// Font name not in the spec allow-list (`JID_CHAR_SHAPE_FONT = JID_CHAR_SHAPE + 4`).
 pub const CHARSHAPE_FONT: u32 = 1004;
 
+/// Relative size outside the allowed range (`JID_CHAR_SHAPE_RSIZE = JID_CHAR_SHAPE + 5`).
+pub const CHARSHAPE_RSIZE: u32 = 1005;
+
+/// Character position outside the allowed range (`JID_CHAR_SHAPE_POSITION = JID_CHAR_SHAPE + 6`).
+pub const CHARSHAPE_POSITION: u32 = 1006;
+
 /// Ratio value outside the allowed range (`JID_CHAR_SHAPE_RATIO = JID_CHAR_SHAPE + 7`).
 pub const CHARSHAPE_RATIO: u32 = 1007;
 
 /// Spacing value outside the allowed range (`JID_CHAR_SHAPE_SPACING = JID_CHAR_SHAPE + 8`).
 pub const CHARSHAPE_SPACING: u32 = 1008;
+
+/// Bold flag mismatch (`JID_CHAR_SHAPE_BOLD = JID_CHAR_SHAPE + 9`).
+pub const CHARSHAPE_BOLD: u32 = 1009;
+
+/// Italic flag mismatch (`JID_CHAR_SHAPE_ITALIC = JID_CHAR_SHAPE + 10`).
+pub const CHARSHAPE_ITALIC: u32 = 1010;
+
+/// Underline flag mismatch (`JID_CHAR_SHAPE_UNDERLINE = JID_CHAR_SHAPE + 11`).
+pub const CHARSHAPE_UNDERLINE: u32 = 1011;
+
+/// Strikeout flag mismatch (`JID_CHAR_SHAPE_STRIKEOUT = JID_CHAR_SHAPE + 12`).
+pub const CHARSHAPE_STRIKEOUT: u32 = 1012;
+
+/// Outline flag mismatch (`JID_CHAR_SHAPE_OUTLINE = JID_CHAR_SHAPE + 13`).
+pub const CHARSHAPE_OUTLINE: u32 = 1013;
+
+/// Emboss flag mismatch (`JID_CHAR_SHAPE_EMBOSS = JID_CHAR_SHAPE + 14`).
+pub const CHARSHAPE_EMBOSS: u32 = 1014;
+
+/// Engrave flag mismatch (`JID_CHAR_SHAPE_ENGRAVE = JID_CHAR_SHAPE + 15`).
+pub const CHARSHAPE_ENGRAVE: u32 = 1015;
+
+/// Shadow flag mismatch (`JID_CHAR_SHAPE_SHADOW = JID_CHAR_SHAPE + 16`).
+pub const CHARSHAPE_SHADOW: u32 = 1016;
+
+/// Superscript flag mismatch (`JID_CHAR_SHAPE_SUPSCRIPT = JID_CHAR_SHAPE + 17`).
+pub const CHARSHAPE_SUPSCRIPT: u32 = 1017;
+
+/// Subscript flag mismatch (`JID_CHAR_SHAPE_SUBSCRIPT = JID_CHAR_SHAPE + 18`).
+pub const CHARSHAPE_SUBSCRIPT: u32 = 1018;
+
+/// Shadow type mismatch (`JID_CHAR_SHAPE_SHADOWTYPE = JID_CHAR_SHAPE + 19`).
+pub const CHARSHAPE_SHADOWTYPE: u32 = 1019;
+
+/// Shadow X offset mismatch (`JID_CHAR_SHAPE_SHADOW_X = JID_CHAR_SHAPE + 20`).
+pub const CHARSHAPE_SHADOW_X: u32 = 1020;
+
+/// Shadow Y offset mismatch (`JID_CHAR_SHAPE_SHADOW_Y = JID_CHAR_SHAPE + 21`).
+pub const CHARSHAPE_SHADOW_Y: u32 = 1021;
+
+/// Shadow color mismatch (`JID_CHAR_SHAPE_SHADOW_COLOR = JID_CHAR_SHAPE + 22`).
+pub const CHARSHAPE_SHADOW_COLOR: u32 = 1022;
+
+/// Underline position mismatch (`JID_CHAR_SHAPE_UNDERLINE_POSITION = JID_CHAR_SHAPE + 23`).
+pub const CHARSHAPE_UNDERLINE_POSITION: u32 = 1023;
+
+/// Underline shape mismatch (`JID_CHAR_SHAPE_UNDERLINE_SHAPE = JID_CHAR_SHAPE + 24`).
+pub const CHARSHAPE_UNDERLINE_SHAPE: u32 = 1024;
+
+/// Underline color mismatch (`JID_CHAR_SHAPE_UNDERLINE_COLOR = JID_CHAR_SHAPE + 25`).
+pub const CHARSHAPE_UNDERLINE_COLOR: u32 = 1025;
+
+/// Strikeout shape mismatch (`JID_CHAR_SHAPE_STRIKEOUT_SHAPE = JID_CHAR_SHAPE + 26`).
+pub const CHARSHAPE_STRIKEOUT_SHAPE: u32 = 1026;
+
+/// Strikeout color mismatch (`JID_CHAR_SHAPE_STRIKEOUT_COLOR = JID_CHAR_SHAPE + 27`).
+pub const CHARSHAPE_STRIKEOUT_COLOR: u32 = 1027;
+
+/// Outline type mismatch (`JID_CHAR_SHAPE_OUTLINETYPE = JID_CHAR_SHAPE + 28`).
+pub const CHARSHAPE_OUTLINETYPE: u32 = 1028;
+
+/// Empty-space flag mismatch (`JID_CHAR_SHAPE_EMPTYSPACE = JID_CHAR_SHAPE + 29`).
+pub const CHARSHAPE_EMPTYSPACE: u32 = 1029;
+
+/// Point (font-size in points) mismatch (`JID_CHAR_SHAPE_POINT = JID_CHAR_SHAPE + 30`).
+pub const CHARSHAPE_POINT: u32 = 1030;
+
+/// Kerning flag mismatch (`JID_CHAR_SHAPE_KERNING = JID_CHAR_SHAPE + 31`).
+pub const CHARSHAPE_KERNING: u32 = 1031;
+
+/// Background border mismatch (`JID_CHAR_SHAPE_BG_BORDER = JID_CHAR_SHAPE + 32`).
+pub const CHARSHAPE_BG_BORDER: u32 = 1032;
+
+/// Background border position mismatch (`JID_CHAR_SHAPE_BG_BORDER_POSITION = JID_CHAR_SHAPE + 33`).
+pub const CHARSHAPE_BG_BORDER_POSITION: u32 = 1033;
+
+/// Background border-type mismatch (`JID_CHAR_SHAPE_BG_BORDER_BORDERTYPE = JID_CHAR_SHAPE + 34`).
+pub const CHARSHAPE_BG_BORDER_BORDERTYPE: u32 = 1034;
+
+/// Background border size mismatch (`JID_CHAR_SHAPE_BG_BORDER_SIZE = JID_CHAR_SHAPE + 35`).
+pub const CHARSHAPE_BG_BORDER_SIZE: u32 = 1035;
+
+/// Background border color mismatch (`JID_CHAR_SHAPE_BG_BORDER_COLOR = JID_CHAR_SHAPE + 36`).
+pub const CHARSHAPE_BG_BORDER_COLOR: u32 = 1036;
+
+/// Background fill color mismatch (`JID_CHAR_SHAPE_BG_COLOR = JID_CHAR_SHAPE + 37`).
+pub const CHARSHAPE_BG_COLOR: u32 = 1037;
+
+/// Background pattern color mismatch (`JID_CHAR_SHAPE_BG_PATTONCOLOR = JID_CHAR_SHAPE + 38`).
+pub const CHARSHAPE_BG_PATTONCOLOR: u32 = 1038;
+
+/// Background pattern type mismatch (`JID_CHAR_SHAPE_BG_PATTONTYPE = JID_CHAR_SHAPE + 39`).
+pub const CHARSHAPE_BG_PATTONTYPE: u32 = 1039;
 
 /// Outline-shape error codes within the [`ErrorCode::OutlineShape`] (3200) range.
 ///

--- a/crates/hwp-dvc-core/src/error/messages.rs
+++ b/crates/hwp-dvc-core/src/error/messages.rs
@@ -55,10 +55,45 @@ impl<'a> ErrorContext<'a> {
 /// separately in [`error_string`].
 const STATIC_MESSAGES_KO: &[(u32, &str)] = &[
     // ── CharShape (1000-range) ────────────────────────────────────────────
+    (1001, "글자 크기가 허용된 범위를 벗어났습니다"),
+    (1002, "언어 세트가 허용되지 않습니다"),
     (1003, "언어 종류가 허용되지 않습니다"),
     // 1004 is dynamic — see error_string()
+    (1005, "글자 상대 크기가 허용된 범위를 벗어났습니다"),
+    (1006, "글자 위치가 허용된 범위를 벗어났습니다"),
     (1007, "글자 장평 값이 허용된 범위를 벗어났습니다"),
     (1008, "글자 자간 값이 허용된 범위를 벗어났습니다"),
+    (1009, "굵게 속성이 허용되지 않습니다"),
+    (1010, "기울임꼴 속성이 허용되지 않습니다"),
+    (1011, "밑줄 속성이 허용되지 않습니다"),
+    (1012, "취소선 속성이 허용되지 않습니다"),
+    (1013, "외곽선 속성이 허용되지 않습니다"),
+    (1014, "양각 속성이 허용되지 않습니다"),
+    (1015, "음각 속성이 허용되지 않습니다"),
+    (1016, "그림자 속성이 허용되지 않습니다"),
+    (1017, "위첨자 속성이 허용되지 않습니다"),
+    (1018, "아래첨자 속성이 허용되지 않습니다"),
+    (1019, "그림자 종류가 허용되지 않습니다"),
+    (1020, "그림자 X 방향 오프셋이 허용된 범위를 벗어났습니다"),
+    (1021, "그림자 Y 방향 오프셋이 허용된 범위를 벗어났습니다"),
+    (1022, "그림자 색상이 허용되지 않습니다"),
+    (1023, "밑줄 위치가 허용되지 않습니다"),
+    (1024, "밑줄 모양이 허용되지 않습니다"),
+    (1025, "밑줄 색상이 허용되지 않습니다"),
+    (1026, "취소선 모양이 허용되지 않습니다"),
+    (1027, "취소선 색상이 허용되지 않습니다"),
+    (1028, "외곽선 종류가 허용되지 않습니다"),
+    (1029, "빈 칸 사용 속성이 허용되지 않습니다"),
+    (1030, "글자 크기(포인트)가 허용된 범위를 벗어났습니다"),
+    (1031, "커닝 속성이 허용되지 않습니다"),
+    (1032, "글자 배경 테두리가 허용되지 않습니다"),
+    (1033, "글자 배경 테두리 위치가 허용되지 않습니다"),
+    (1034, "글자 배경 테두리 종류가 허용되지 않습니다"),
+    (1035, "글자 배경 테두리 굵기가 허용되지 않습니다"),
+    (1036, "글자 배경 테두리 색상이 허용되지 않습니다"),
+    (1037, "글자 배경 색상이 허용되지 않습니다"),
+    (1038, "글자 배경 패턴 색상이 허용되지 않습니다"),
+    (1039, "글자 배경 패턴 종류가 허용되지 않습니다"),
     // ── ParaShape (2000-range) ────────────────────────────────────────────
     (2004, "첫째 줄 들여쓰기 값이 허용된 범위를 벗어났습니다"),
     (2005, "들여쓰기 값이 허용된 범위를 벗어났습니다"),
@@ -98,10 +133,45 @@ const STATIC_MESSAGES_KO: &[(u32, &str)] = &[
 
 /// Static English message table (used when `HWP_DVC_LANG=en`).
 const STATIC_MESSAGES_EN: &[(u32, &str)] = &[
+    (1001, "font size is out of the allowed range"),
+    (1002, "language set is not allowed"),
     (1003, "language type is not allowed"),
     // 1004 is dynamic
+    (1005, "relative character size is out of the allowed range"),
+    (1006, "character position is out of the allowed range"),
     (1007, "character ratio is out of the allowed range"),
     (1008, "character spacing is out of the allowed range"),
+    (1009, "bold attribute is not allowed"),
+    (1010, "italic attribute is not allowed"),
+    (1011, "underline attribute is not allowed"),
+    (1012, "strikeout attribute is not allowed"),
+    (1013, "outline attribute is not allowed"),
+    (1014, "emboss attribute is not allowed"),
+    (1015, "engrave attribute is not allowed"),
+    (1016, "shadow attribute is not allowed"),
+    (1017, "superscript attribute is not allowed"),
+    (1018, "subscript attribute is not allowed"),
+    (1019, "shadow type is not allowed"),
+    (1020, "shadow X offset is out of the allowed range"),
+    (1021, "shadow Y offset is out of the allowed range"),
+    (1022, "shadow color is not allowed"),
+    (1023, "underline position is not allowed"),
+    (1024, "underline shape is not allowed"),
+    (1025, "underline color is not allowed"),
+    (1026, "strikeout shape is not allowed"),
+    (1027, "strikeout color is not allowed"),
+    (1028, "outline type is not allowed"),
+    (1029, "empty-space attribute is not allowed"),
+    (1030, "font size in points is out of the allowed range"),
+    (1031, "kerning attribute is not allowed"),
+    (1032, "character background border is not allowed"),
+    (1033, "character background border position is not allowed"),
+    (1034, "character background border type is not allowed"),
+    (1035, "character background border size is not allowed"),
+    (1036, "character background border color is not allowed"),
+    (1037, "character background color is not allowed"),
+    (1038, "character background pattern color is not allowed"),
+    (1039, "character background pattern type is not allowed"),
     (2004, "first-line indent is out of the allowed range"),
     (2005, "paragraph indent is out of the allowed range"),
     (2006, "paragraph outdent is out of the allowed range"),
@@ -114,8 +184,14 @@ const STATIC_MESSAGES_EN: &[(u32, &str)] = &[
     (3034, "table border line width is not allowed"),
     (3035, "table border color is not allowed"),
     (3056, "table inside table is not allowed"),
-    (3101, "text contains a special character below the allowed minimum"),
-    (3102, "text contains a special character above the allowed maximum"),
+    (
+        3101,
+        "text contains a special character below the allowed minimum",
+    ),
+    (
+        3102,
+        "text contains a special character above the allowed maximum",
+    ),
     (3201, "outline shape type is not allowed"),
     (3206, "outline level number format is not allowed"),
     (3207, "outline level number shape is not allowed"),
@@ -226,7 +302,10 @@ mod tests {
     #[test]
     fn charshape_font_without_name_contains_glyph_word() {
         let msg = error_string(1004, ctx());
-        assert!(msg.contains("글꼴"), "1004 without name must mention 글꼴: {msg}");
+        assert!(
+            msg.contains("글꼴"),
+            "1004 without name must mention 글꼴: {msg}"
+        );
     }
 
     #[test]
@@ -270,7 +349,10 @@ mod tests {
     #[test]
     fn bullet_shapes_without_char_contains_bullet_word() {
         let msg = error_string(3304, ctx());
-        assert!(msg.contains("글머리표"), "3304 without char must mention 글머리표: {msg}");
+        assert!(
+            msg.contains("글머리표"),
+            "3304 without char must mention 글머리표: {msg}"
+        );
     }
 
     #[test]
@@ -280,7 +362,10 @@ mod tests {
             ..Default::default()
         };
         let msg = error_string(3304, ctx);
-        assert!(msg.contains("□"), "3304 with char must include the char: {msg}");
+        assert!(
+            msg.contains("□"),
+            "3304 with char must include the char: {msg}"
+        );
         assert!(msg.contains("글머리표"), "must mention 글머리표: {msg}");
     }
 
@@ -308,15 +393,29 @@ mod tests {
     #[test]
     fn unknown_code_returns_empty_string() {
         let msg = error_string(9999, ctx());
-        assert!(msg.is_empty(), "unknown code must return empty string: {msg}");
+        assert!(
+            msg.is_empty(),
+            "unknown code must return empty string: {msg}"
+        );
     }
 
     #[test]
     fn all_documented_codes_have_non_empty_messages() {
         let codes: &[u32] = &[
-            1003, 1004, 1007, 1008, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 3004, 3033, 3034,
-            3035, 3056, 3101, 3102, 3201, 3206, 3207, 3302, 3303, 3304, 3401, 3406, 3407, 3502,
-            6901, 7001,
+            // CharShape (1000-range)
+            1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014,
+            1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1028,
+            1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039,
+            // ParaShape (2000-range)
+            2004, 2005, 2006, 2007, 2008, 2009, 2010, // Table (3000-range)
+            3004, 3033, 3034, 3035, 3056, // SpecialCharacter (3100-range)
+            3101, 3102, // OutlineShape (3200-range)
+            3201, 3206, 3207, // Bullet (3300-range)
+            3302, 3303, 3304, // ParaNumBullet (3400-range)
+            3401, 3406, 3407, // Style (3500-range)
+            3502, // Hyperlink (6900-range)
+            6901, // Macro (7000-range)
+            7001,
         ];
         for &code in codes {
             let msg = error_string(code, ctx());

--- a/crates/hwp-dvc-core/src/output/xml.rs
+++ b/crates/hwp-dvc-core/src/output/xml.rs
@@ -98,5 +98,9 @@ fn write_elem(w: &mut XmlWriter<'_>, tag: &str, value: &str) -> Result<(), quick
 
 #[inline]
 const fn bool_str(v: bool) -> &'static str {
-    if v { "true" } else { "false" }
+    if v {
+        "true"
+    } else {
+        "false"
+    }
 }

--- a/crates/hwp-dvc-core/src/spec/mod.rs
+++ b/crates/hwp-dvc-core/src/spec/mod.rs
@@ -35,8 +35,20 @@ pub struct DvcSpec {
     pub macro_: Option<MacroSpec>,
 }
 
+/// Spec for the background-border sub-check within CharShape.
+///
+/// Maps to `JID_CHAR_SHAPE_BG_BORDER_*` (1032–1036) in `JsonModel.h`.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CharShapeBorderSpec {
+    pub position: Option<u32>,
+    pub bordertype: Option<u32>,
+    pub size: Option<f64>,
+    pub color: Option<String>,
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CharShapeSpec {
+    // ── existing fields (1000-range) ─────────────────────────────────────
     #[serde(default)]
     pub langtype: Option<String>,
     #[serde(default)]
@@ -45,6 +57,114 @@ pub struct CharShapeSpec {
     pub ratio: Option<i32>,
     #[serde(default)]
     pub spacing: Option<i32>,
+
+    // ── size group (1001, 1005, 1006, 1030) ──────────────────────────────
+    /// Font size in 0.1pt units (`JID_CHAR_SHAPE_FONTSIZE = 1001`).
+    #[serde(default)]
+    pub fontsize: Option<u32>,
+    /// Relative size percentage (`JID_CHAR_SHAPE_RSIZE = 1005`).
+    #[serde(default)]
+    pub rsize: Option<u32>,
+    /// Character position in 0.1pt units (`JID_CHAR_SHAPE_POSITION = 1006`).
+    #[serde(default)]
+    pub position: Option<i32>,
+    /// Font size in points (`JID_CHAR_SHAPE_POINT = 1030`).
+    #[serde(default)]
+    pub point: Option<f64>,
+
+    // ── text decoration toggles (1009–1018) ───────────────────────────────
+    /// Bold flag (`JID_CHAR_SHAPE_BOLD = 1009`).
+    #[serde(default)]
+    pub bold: Option<bool>,
+    /// Italic flag (`JID_CHAR_SHAPE_ITALIC = 1010`).
+    #[serde(default)]
+    pub italic: Option<bool>,
+    /// Underline flag (`JID_CHAR_SHAPE_UNDERLINE = 1011`).
+    #[serde(default)]
+    pub underline: Option<bool>,
+    /// Strikeout flag (`JID_CHAR_SHAPE_STRIKEOUT = 1012`).
+    #[serde(default)]
+    pub strikeout: Option<bool>,
+    /// Outline flag (`JID_CHAR_SHAPE_OUTLINE = 1013`).
+    #[serde(default)]
+    pub outline: Option<bool>,
+    /// Emboss flag (`JID_CHAR_SHAPE_EMBOSS = 1014`).
+    #[serde(default)]
+    pub emboss: Option<bool>,
+    /// Engrave flag (`JID_CHAR_SHAPE_ENGRAVE = 1015`).
+    #[serde(default)]
+    pub engrave: Option<bool>,
+    /// Shadow flag (`JID_CHAR_SHAPE_SHADOW = 1016`).
+    #[serde(default)]
+    pub shadow: Option<bool>,
+    /// Superscript flag (`JID_CHAR_SHAPE_SUPSCRIPT = 1017`).
+    #[serde(default)]
+    pub supscript: Option<bool>,
+    /// Subscript flag (`JID_CHAR_SHAPE_SUBSCRIPT = 1018`).
+    #[serde(default)]
+    pub subscript: Option<bool>,
+
+    // ── shadow detail (1019–1022) ─────────────────────────────────────────
+    /// Shadow type string (`JID_CHAR_SHAPE_SHADOWTYPE = 1019`).
+    #[serde(default)]
+    pub shadowtype: Option<String>,
+    /// Shadow X offset (`JID_CHAR_SHAPE_SHADOW_X = 1020`).
+    #[serde(rename = "shadow-x", default)]
+    pub shadow_x: Option<i32>,
+    /// Shadow Y offset (`JID_CHAR_SHAPE_SHADOW_Y = 1021`).
+    #[serde(rename = "shadow-y", default)]
+    pub shadow_y: Option<i32>,
+    /// Shadow color hex string (`JID_CHAR_SHAPE_SHADOW_COLOR = 1022`).
+    #[serde(rename = "shadow-color", default)]
+    pub shadow_color: Option<String>,
+
+    // ── underline detail (1023–1025) ──────────────────────────────────────
+    /// Underline position string (`JID_CHAR_SHAPE_UNDERLINE_POSITION = 1023`).
+    #[serde(rename = "underline-position", default)]
+    pub underline_position: Option<String>,
+    /// Underline shape string (`JID_CHAR_SHAPE_UNDERLINE_SHAPE = 1024`).
+    #[serde(rename = "underline-shape", default)]
+    pub underline_shape: Option<String>,
+    /// Underline color hex string (`JID_CHAR_SHAPE_UNDERLINE_COLOR = 1025`).
+    #[serde(rename = "underline-color", default)]
+    pub underline_color: Option<String>,
+
+    // ── strikeout detail (1026–1027) ──────────────────────────────────────
+    /// Strikeout shape string (`JID_CHAR_SHAPE_STRIKEOUT_SHAPE = 1026`).
+    #[serde(rename = "strikeout-shape", default)]
+    pub strikeout_shape: Option<String>,
+    /// Strikeout color hex string (`JID_CHAR_SHAPE_STRIKEOUT_COLOR = 1027`).
+    #[serde(rename = "strikeout-color", default)]
+    pub strikeout_color: Option<String>,
+
+    // ── outline detail (1028) ─────────────────────────────────────────────
+    /// Outline type string (`JID_CHAR_SHAPE_OUTLINETYPE = 1028`).
+    #[serde(default)]
+    pub outlinetype: Option<String>,
+
+    // ── misc (1029, 1031) ─────────────────────────────────────────────────
+    /// Empty-space flag (`JID_CHAR_SHAPE_EMPTYSPACE = 1029`).
+    #[serde(default)]
+    pub emptyspace: Option<bool>,
+    /// Kerning flag (`JID_CHAR_SHAPE_KERNING = 1031`).
+    #[serde(default)]
+    pub kerning: Option<bool>,
+
+    // ── border (1032–1036) ────────────────────────────────────────────────
+    /// Background border object (`JID_CHAR_SHAPE_BG_BORDER = 1032`).
+    #[serde(default)]
+    pub border: Option<CharShapeBorderSpec>,
+
+    // ── background (1037–1039) ────────────────────────────────────────────
+    /// Background fill color hex string (`JID_CHAR_SHAPE_BG_COLOR = 1037`).
+    #[serde(rename = "bg-color", default)]
+    pub bg_color: Option<String>,
+    /// Background pattern color hex string (`JID_CHAR_SHAPE_BG_PATTONCOLOR = 1038`).
+    #[serde(rename = "bg-pattoncolor", default)]
+    pub bg_pattoncolor: Option<String>,
+    /// Background pattern type string (`JID_CHAR_SHAPE_BG_PATTONTYPE = 1039`).
+    #[serde(rename = "bg-pattontype", default)]
+    pub bg_pattontype: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/hwp-dvc-core/tests/check_char_shape_extended.rs
+++ b/crates/hwp-dvc-core/tests/check_char_shape_extended.rs
@@ -1,0 +1,857 @@
+//! Extended integration tests for `checker::char_shape::check` — issue #39.
+//!
+//! This suite verifies the 37 new `JID_CHAR_SHAPE_*` fields added by issue #39
+//! beyond the original four (langtype, font, ratio, spacing).
+//!
+//! # Fixture strategy
+//!
+//! All tests in this file work against the existing `charshape_pass.hwpx`
+//! fixture (authored via 한글, committed for the original charshape issue).
+//! We do not require new `.hwpx` files to be authored in 한글 for the pure
+//! boolean-flag / numeric-range checks; instead, we exercise the validator
+//! logic directly with synthetic in-memory `CharShape` and `CharShapeSpec`
+//! objects.
+//!
+//! Tests that require a real fixture document (baseline pass) reuse
+//! `charshape_pass.hwpx` to confirm zero 1000-range errors when all new
+//! spec fields are absent (i.e., `None`).
+//!
+//! The decoration-fail sub-case is verified via the unit-test-level path
+//! in `checker/char_shape/mod.rs`. A fixture-level bold-fail variant
+//! (`charshape_fail_bold.hwpx`) cannot be synthesized via XML patching
+//! because the OWPML `<hh:bold/>` element presence/absence requires
+//! re-authoring in 한글 — see `tests/fixtures/docs/README.md` for the
+//! authoring procedure when this fixture is eventually needed.
+//!
+//! # Coverage summary
+//!
+//! | Group               | Codes      | Strategy                          |
+//! |---------------------|------------|-----------------------------------|
+//! | Size                | 1001,1005,1006,1030 | Synthetic CharShape + Spec  |
+//! | Decoration flags    | 1009–1018  | Synthetic CharShape + Spec        |
+//! | Shadow detail       | 1019–1022  | TODO — deferred (no CharShape field)|
+//! | Underline detail    | 1023–1025  | TODO — deferred (no CharShape field)|
+//! | Strikeout detail    | 1026–1027  | TODO — deferred (no CharShape field)|
+//! | Outline detail      | 1028       | TODO — deferred (no CharShape field)|
+//! | Misc                | 1029,1031  | Synthetic CharShape + Spec        |
+//! | Border presence     | 1032       | Synthetic CharShape + Spec        |
+//! | Background          | 1037–1039  | TODO — deferred (no CharShape field)|
+//! | Baseline pass       | all        | charshape_pass.hwpx               |
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use hwp_dvc_core::checker::char_shape::{
+    self, CHARSHAPE_BG_BORDER, CHARSHAPE_BOLD, CHARSHAPE_EMBOSS, CHARSHAPE_EMPTYSPACE,
+    CHARSHAPE_ENGRAVE, CHARSHAPE_FONTSIZE, CHARSHAPE_ITALIC, CHARSHAPE_KERNING, CHARSHAPE_OUTLINE,
+    CHARSHAPE_POINT, CHARSHAPE_POSITION, CHARSHAPE_RSIZE, CHARSHAPE_SHADOW, CHARSHAPE_STRIKEOUT,
+    CHARSHAPE_SUBSCRIPT, CHARSHAPE_SUPSCRIPT, CHARSHAPE_UNDERLINE,
+};
+use hwp_dvc_core::checker::CheckLevel;
+use hwp_dvc_core::document::header::{CharShape, FontFace, FontLang, HeaderTables, LangTuple};
+use hwp_dvc_core::document::{Document, RunTypeInfo};
+use hwp_dvc_core::spec::{CharShapeBorderSpec, CharShapeSpec, DvcSpec};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shared test helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn fixture_doc(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/docs");
+    p.push(name);
+    p
+}
+
+fn fixture_spec(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/specs");
+    p.push(name);
+    p
+}
+
+fn load_doc(name: &str) -> Document {
+    let mut doc = Document::open(fixture_doc(name))
+        .unwrap_or_else(|e| panic!("failed to open fixture {name}: {e}"));
+    doc.parse()
+        .unwrap_or_else(|e| panic!("failed to parse fixture {name}: {e}"));
+    doc
+}
+
+fn load_spec(name: &str) -> DvcSpec {
+    DvcSpec::from_json_file(fixture_spec(name))
+        .unwrap_or_else(|e| panic!("failed to load spec {name}: {e}"))
+}
+
+/// Build a minimal `HeaderTables` with a single `CharShape` and one `FontFace`.
+fn tables_with(cs: CharShape) -> HeaderTables {
+    let mut char_shapes = HashMap::new();
+    char_shapes.insert(cs.id, cs);
+    HeaderTables {
+        char_shapes,
+        font_faces: vec![FontFace {
+            lang: FontLang::Hangul,
+            fonts: {
+                let mut m = HashMap::new();
+                m.insert(0, "함초롬바탕".to_string());
+                m.insert(1, "함초롬돋움".to_string());
+                m
+            },
+        }],
+        ..Default::default()
+    }
+}
+
+fn run_for(char_pr_id_ref: u32) -> RunTypeInfo {
+    RunTypeInfo {
+        char_pr_id_ref,
+        text: "테스트".to_string(),
+        ..Default::default()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Baseline pass test using real fixture
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// When all new spec fields are `None`, the existing `charshape_pass.hwpx`
+/// must still produce zero 1000-range errors.
+#[test]
+fn charshape_pass_with_extended_spec_none_fields_produces_no_errors() {
+    let doc = load_doc("charshape_pass.hwpx");
+    let base_spec = load_spec("fixture_spec.json");
+
+    let header = doc.header.as_ref().expect("header must be parsed");
+    let base_charshape = base_spec.charshape.as_ref().expect("charshape must be set");
+
+    // Build an extended spec that carries all the new None fields on top of the
+    // existing font/ratio/spacing constraints.
+    let extended_spec = CharShapeSpec {
+        langtype: base_charshape.langtype.clone(),
+        font: base_charshape.font.clone(),
+        ratio: base_charshape.ratio,
+        spacing: base_charshape.spacing,
+        // All new fields absent — must not trigger any new errors.
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&extended_spec, header, &doc.run_type_infos, CheckLevel::All);
+
+    let charshape_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code >= 1000 && e.error_code < 2000)
+        .collect();
+
+    assert!(
+        charshape_errors.is_empty(),
+        "charshape_pass with all new spec fields = None must produce zero 1000-range errors; \
+         got {} error(s): {:?}",
+        charshape_errors.len(),
+        charshape_errors,
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Size group: fontsize (1001), rsize (1005), position (1006), point (1030)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fontsize_match_no_error() {
+    let mut cs = CharShape {
+        id: 0,
+        height: 1000,
+        ..Default::default()
+    };
+    cs.font_ref.set(FontLang::Hangul, 0);
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        fontsize: Some(1000),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_FONTSIZE),
+        "fontsize match must produce no CHARSHAPE_FONTSIZE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn fontsize_mismatch_produces_error() {
+    let mut cs = CharShape {
+        id: 0,
+        height: 1200,
+        ..Default::default()
+    };
+    cs.font_ref.set(FontLang::Hangul, 0);
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        fontsize: Some(1000),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_FONTSIZE),
+        "expected CHARSHAPE_FONTSIZE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn rsize_mismatch_produces_error() {
+    let mut cs = CharShape {
+        id: 0,
+        ..Default::default()
+    };
+    cs.font_ref.set(FontLang::Hangul, 0);
+    let mut rel_sz = LangTuple::<u32>::default();
+    rel_sz.set(FontLang::Hangul, 80);
+    cs.rel_sz = rel_sz;
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        rsize: Some(100),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_RSIZE),
+        "expected CHARSHAPE_RSIZE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn position_mismatch_produces_error() {
+    let mut cs = CharShape {
+        id: 0,
+        ..Default::default()
+    };
+    cs.font_ref.set(FontLang::Hangul, 0);
+    let mut offset = LangTuple::<i32>::default();
+    offset.set(FontLang::Hangul, 5);
+    cs.offset = offset;
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        position: Some(0),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_POSITION),
+        "expected CHARSHAPE_POSITION error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn point_match_no_error() {
+    let cs = CharShape {
+        id: 0,
+        height: 1000,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        point: Some(10.0),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_POINT),
+        "point match must produce no CHARSHAPE_POINT error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn point_mismatch_produces_error() {
+    let cs = CharShape {
+        id: 0,
+        height: 1200,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        point: Some(10.0),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_POINT),
+        "expected CHARSHAPE_POINT error (12pt vs 10pt spec); got: {errors:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Text decoration toggles (1009–1018)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn decoration_flags_match_produce_no_errors() {
+    let cs = CharShape {
+        id: 0,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikeout: false,
+        outline: false,
+        emboss: false,
+        engrave: false,
+        shadow: false,
+        supscript: false,
+        subscript: false,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        bold: Some(false),
+        italic: Some(false),
+        underline: Some(false),
+        strikeout: Some(false),
+        outline: Some(false),
+        emboss: Some(false),
+        engrave: Some(false),
+        shadow: Some(false),
+        supscript: Some(false),
+        subscript: Some(false),
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    let decoration_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| e.error_code >= 1009 && e.error_code <= 1018)
+        .collect();
+    assert!(
+        decoration_errors.is_empty(),
+        "all-false decoration flags must produce no 1009-1018 errors; got: {decoration_errors:?}"
+    );
+}
+
+#[test]
+fn bold_true_when_spec_false_produces_bold_error() {
+    let cs = CharShape {
+        id: 0,
+        bold: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        bold: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_BOLD),
+        "expected CHARSHAPE_BOLD error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn italic_mismatch_produces_italic_error() {
+    let cs = CharShape {
+        id: 0,
+        italic: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        italic: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_ITALIC),
+        "expected CHARSHAPE_ITALIC error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn underline_mismatch_produces_underline_error() {
+    let cs = CharShape {
+        id: 0,
+        underline: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        underline: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_UNDERLINE),
+        "expected CHARSHAPE_UNDERLINE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn strikeout_mismatch_produces_strikeout_error() {
+    let cs = CharShape {
+        id: 0,
+        strikeout: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        strikeout: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_STRIKEOUT),
+        "expected CHARSHAPE_STRIKEOUT error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn outline_mismatch_produces_outline_error() {
+    let cs = CharShape {
+        id: 0,
+        outline: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        outline: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_OUTLINE),
+        "expected CHARSHAPE_OUTLINE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn emboss_mismatch_produces_emboss_error() {
+    let cs = CharShape {
+        id: 0,
+        emboss: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        emboss: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_EMBOSS),
+        "expected CHARSHAPE_EMBOSS error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn engrave_mismatch_produces_engrave_error() {
+    let cs = CharShape {
+        id: 0,
+        engrave: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        engrave: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_ENGRAVE),
+        "expected CHARSHAPE_ENGRAVE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn shadow_mismatch_produces_shadow_error() {
+    let cs = CharShape {
+        id: 0,
+        shadow: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        shadow: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_SHADOW),
+        "expected CHARSHAPE_SHADOW error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn supscript_mismatch_produces_supscript_error() {
+    let cs = CharShape {
+        id: 0,
+        supscript: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        supscript: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_SUPSCRIPT),
+        "expected CHARSHAPE_SUPSCRIPT error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn subscript_mismatch_produces_subscript_error() {
+    let cs = CharShape {
+        id: 0,
+        subscript: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        subscript: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_SUBSCRIPT),
+        "expected CHARSHAPE_SUBSCRIPT error; got: {errors:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Misc: emptyspace (1029), kerning (1031)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn emptyspace_mismatch_produces_error() {
+    let cs = CharShape {
+        id: 0,
+        use_font_space: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        emptyspace: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_EMPTYSPACE),
+        "expected CHARSHAPE_EMPTYSPACE error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn emptyspace_match_no_error() {
+    let cs = CharShape {
+        id: 0,
+        use_font_space: false,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        emptyspace: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_EMPTYSPACE),
+        "no CHARSHAPE_EMPTYSPACE error expected; got: {errors:?}"
+    );
+}
+
+#[test]
+fn kerning_mismatch_produces_error() {
+    let cs = CharShape {
+        id: 0,
+        use_kerning: true,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        kerning: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_KERNING),
+        "expected CHARSHAPE_KERNING error; got: {errors:?}"
+    );
+}
+
+#[test]
+fn kerning_match_no_error() {
+    let cs = CharShape {
+        id: 0,
+        use_kerning: false,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        kerning: Some(false),
+        ..Default::default()
+    };
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_KERNING),
+        "no CHARSHAPE_KERNING error expected; got: {errors:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Border presence (1032)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bg_border_absent_with_spec_produces_bg_border_error() {
+    let cs = CharShape {
+        id: 0,
+        border_fill_id_ref: 0,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        border: Some(CharShapeBorderSpec {
+            position: Some(1),
+            bordertype: Some(1),
+            size: Some(0.12),
+            color: Some("#000000".to_string()),
+        }),
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().any(|e| e.error_code == CHARSHAPE_BG_BORDER),
+        "expected CHARSHAPE_BG_BORDER error when border_fill_id_ref=0; got: {errors:?}"
+    );
+}
+
+#[test]
+fn bg_border_present_with_spec_no_bg_border_error() {
+    let cs = CharShape {
+        id: 0,
+        border_fill_id_ref: 1,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        border: Some(CharShapeBorderSpec::default()),
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_BG_BORDER),
+        "no CHARSHAPE_BG_BORDER error expected when border_fill present; got: {errors:?}"
+    );
+}
+
+#[test]
+fn bg_border_spec_absent_no_bg_border_error() {
+    let cs = CharShape {
+        id: 0,
+        border_fill_id_ref: 0,
+        ..Default::default()
+    };
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        border: None,
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    assert!(
+        errors.iter().all(|e| e.error_code != CHARSHAPE_BG_BORDER),
+        "no CHARSHAPE_BG_BORDER error expected when spec.border is None; got: {errors:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Multi-field spec: all active, all matching — zero errors
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn all_new_fields_matching_produce_no_errors() {
+    let mut cs = CharShape {
+        id: 0,
+        height: 1000,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikeout: false,
+        outline: false,
+        emboss: false,
+        engrave: false,
+        shadow: false,
+        supscript: false,
+        subscript: false,
+        use_font_space: false,
+        use_kerning: false,
+        border_fill_id_ref: 1, // border present
+        ..Default::default()
+    };
+    let mut rel_sz = LangTuple::<u32>::default();
+    rel_sz.set(FontLang::Hangul, 100);
+    cs.rel_sz = rel_sz;
+    let mut offset = LangTuple::<i32>::default();
+    offset.set(FontLang::Hangul, 0);
+    cs.offset = offset;
+
+    let tables = tables_with(cs);
+    let runs = vec![run_for(0)];
+
+    let spec = CharShapeSpec {
+        fontsize: Some(1000),
+        rsize: Some(100),
+        position: Some(0),
+        point: Some(10.0),
+        bold: Some(false),
+        italic: Some(false),
+        underline: Some(false),
+        strikeout: Some(false),
+        outline: Some(false),
+        emboss: Some(false),
+        engrave: Some(false),
+        shadow: Some(false),
+        supscript: Some(false),
+        subscript: Some(false),
+        emptyspace: Some(false),
+        kerning: Some(false),
+        border: Some(CharShapeBorderSpec::default()),
+        ..Default::default()
+    };
+
+    let errors = char_shape::check(&spec, &tables, &runs, CheckLevel::All);
+    let new_field_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.error_code,
+                1001 | 1005 | 1006 | 1009..=1018 | 1029..=1032
+            )
+        })
+        .collect();
+
+    assert!(
+        new_field_errors.is_empty(),
+        "all matching new fields must produce no errors; got: {new_field_errors:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Spec field JSON round-trip: extended fields survive serialization
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn extended_charshape_spec_fields_roundtrip_json() {
+    // Build the JSON programmatically to avoid raw-string delimiter conflicts
+    // with the '#' character in color values.
+    let json = serde_json::json!({
+        "charshape": {
+            "font": ["함초롬바탕"],
+            "fontsize": 1000,
+            "rsize": 100,
+            "position": 0,
+            "point": 10.0_f64,
+            "bold": false,
+            "italic": false,
+            "underline": false,
+            "strikeout": false,
+            "outline": false,
+            "emboss": false,
+            "engrave": false,
+            "shadow": false,
+            "supscript": false,
+            "subscript": false,
+            "shadow-x": 10,
+            "shadow-y": 10,
+            "shadow-color": "#C0C0C0",
+            "underline-position": "BOTTOM",
+            "underline-shape": "SOLID",
+            "underline-color": "#000000",
+            "strikeout-shape": "SOLID",
+            "strikeout-color": "#000000",
+            "outlinetype": "NONE",
+            "emptyspace": false,
+            "kerning": false,
+            "bg-color": "#FFFFFF",
+            "bg-pattoncolor": "#000000",
+            "bg-pattontype": "NONE"
+        }
+    })
+    .to_string();
+
+    let spec =
+        DvcSpec::from_json_str(&json).expect("extended charshape spec JSON must parse cleanly");
+    let cs = spec.charshape.unwrap();
+
+    assert_eq!(cs.fontsize, Some(1000));
+    assert_eq!(cs.rsize, Some(100));
+    assert_eq!(cs.position, Some(0));
+    // serde_json round-trips f64 so we check with a tolerance
+    assert!(
+        (cs.point.unwrap_or(0.0) - 10.0_f64).abs() < 0.01,
+        "point must be ~10.0; got {:?}",
+        cs.point
+    );
+    assert_eq!(cs.bold, Some(false));
+    assert_eq!(cs.italic, Some(false));
+    assert_eq!(cs.shadow_x, Some(10));
+    assert_eq!(cs.shadow_y, Some(10));
+    assert_eq!(cs.shadow_color.as_deref(), Some("#C0C0C0"));
+    assert_eq!(cs.underline_position.as_deref(), Some("BOTTOM"));
+    assert_eq!(cs.underline_shape.as_deref(), Some("SOLID"));
+    assert_eq!(cs.underline_color.as_deref(), Some("#000000"));
+    assert_eq!(cs.strikeout_shape.as_deref(), Some("SOLID"));
+    assert_eq!(cs.strikeout_color.as_deref(), Some("#000000"));
+    assert_eq!(cs.outlinetype.as_deref(), Some("NONE"));
+    assert_eq!(cs.emptyspace, Some(false));
+    assert_eq!(cs.kerning, Some(false));
+    assert_eq!(cs.bg_color.as_deref(), Some("#FFFFFF"));
+    assert_eq!(cs.bg_pattoncolor.as_deref(), Some("#000000"));
+    assert_eq!(cs.bg_pattontype.as_deref(), Some("NONE"));
+}

--- a/crates/hwp-dvc-core/tests/fixtures/docs/README.md
+++ b/crates/hwp-dvc-core/tests/fixtures/docs/README.md
@@ -157,6 +157,17 @@ a matter of typing the sample text into a blank document and saving.
 - Leave font and spacing at baseline.
 - Expected: **1 error** in the 1000 range for ratio.
 
+#### `charshape_fail_bold.hwpx` ⏳ (needs 한글 authoring)
+- Baseline body **plus** one paragraph where bold is set via
+  `서식 → 글자 모양 → 굵게`.
+- Spec field: `"bold": false`.
+- This fixture cannot be synthesized via XML patching because the
+  OWPML `<hh:bold/>` element's presence/absence must round-trip
+  through 한글's charPr table.
+- Once authored, add to `fixture_spec.json` as `"bold": false` and
+  add a test in `check_char_shape_extended.rs` mirroring the font-fail
+  pattern. Error code: `CHARSHAPE_BOLD (1009)`.
+
 ---
 
 ### ParaShape

--- a/crates/hwp-dvc-core/tests/korean_error_messages.rs
+++ b/crates/hwp-dvc-core/tests/korean_error_messages.rs
@@ -75,10 +75,7 @@ fn charshape_fail_font_error_string_contains_font_word() {
     let spec = load_spec();
     let errors = run_checker(&doc, &spec);
 
-    let font_errors: Vec<_> = errors
-        .iter()
-        .filter(|e| e.error_code == 1004)
-        .collect();
+    let font_errors: Vec<_> = errors.iter().filter(|e| e.error_code == 1004).collect();
 
     assert!(
         !font_errors.is_empty(),
@@ -119,10 +116,7 @@ fn macro_present_error_string_contains_macro_word() {
 
     let errors = run_checker(&doc, &spec);
 
-    let macro_errors: Vec<_> = errors
-        .iter()
-        .filter(|e| e.error_code == 7001)
-        .collect();
+    let macro_errors: Vec<_> = errors.iter().filter(|e| e.error_code == 7001).collect();
 
     assert!(
         !macro_errors.is_empty(),
@@ -152,16 +146,16 @@ fn hyperlink_external_error_string_contains_hyperlink_word() {
     let spec = load_spec();
     // fixture_spec.json has hyperlink.permission = false
     assert!(
-        spec.hyperlink.as_ref().map(|h| !h.permission).unwrap_or(false),
+        spec.hyperlink
+            .as_ref()
+            .map(|h| !h.permission)
+            .unwrap_or(false),
         "fixture_spec must have hyperlink.permission == false for this test to be meaningful"
     );
 
     let errors = run_checker(&doc, &spec);
 
-    let hyperlink_errors: Vec<_> = errors
-        .iter()
-        .filter(|e| e.error_code == 6901)
-        .collect();
+    let hyperlink_errors: Vec<_> = errors.iter().filter(|e| e.error_code == 6901).collect();
 
     assert!(
         !hyperlink_errors.is_empty(),

--- a/crates/hwp-dvc-core/tests/output_scope.rs
+++ b/crates/hwp-dvc-core/tests/output_scope.rs
@@ -54,7 +54,12 @@ fn load_spec(name: &str) -> DvcSpec {
 }
 
 fn run_with_scope(doc: &Document, spec: &DvcSpec, scope: OutputScope) -> Vec<u32> {
-    let checker = Checker { spec, document: doc, level: CheckLevel::All, scope };
+    let checker = Checker {
+        spec,
+        document: doc,
+        level: CheckLevel::All,
+        scope,
+    };
     checker
         .run()
         .expect("Checker::run must not fail")
@@ -93,7 +98,10 @@ fn charshape_fail_font_table_scope_suppresses_charshape_errors() {
     let doc = load_doc("charshape_fail_font.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { table: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        table: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     let charshape_codes: Vec<u32> = codes
@@ -119,7 +127,10 @@ fn charshape_fail_font_all_scope_emits_charshape_errors() {
     let doc = load_doc("charshape_fail_font.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { all: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        all: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -158,7 +169,10 @@ fn table_nested_hyperlink_scope_suppresses_table_errors() {
     let doc = load_doc("table_nested.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { hyperlink: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        hyperlink: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     let table_codes: Vec<u32> = codes
@@ -184,7 +198,10 @@ fn charshape_fail_font_shape_scope_emits_charshape_errors() {
     let doc = load_doc("charshape_fail_font.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        shape: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -200,7 +217,10 @@ fn charshape_fail_font_shape_scope_suppresses_table_errors() {
     let doc = load_doc("charshape_fail_font.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        shape: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     let table_codes: Vec<u32> = codes
@@ -226,7 +246,10 @@ fn style_custom_style_scope_emits_style_errors() {
     let doc = load_doc("style_custom.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { style: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        style: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -243,7 +266,10 @@ fn style_custom_table_scope_suppresses_style_errors() {
     let doc = load_doc("style_custom.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { table: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        table: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -265,7 +291,10 @@ fn hyperlink_external_hyperlink_scope_emits_hyperlink_errors() {
     let doc = load_doc("hyperlink_external.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { hyperlink: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        hyperlink: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -283,7 +312,10 @@ fn hyperlink_external_style_scope_suppresses_hyperlink_errors() {
     let doc = load_doc("hyperlink_external.hwpx");
     let spec = load_spec("fixture_spec.json");
 
-    let scope = OutputScope { style: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        style: true,
+        ..OutputScope::default()
+    };
     let codes = run_with_scope(&doc, &spec, scope);
 
     assert!(
@@ -312,7 +344,10 @@ fn output_scope_default_is_default() {
 fn output_scope_all_allows_every_category() {
     use hwp_dvc_core::checker::ScopeCategory;
 
-    let scope = OutputScope { all: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        all: true,
+        ..OutputScope::default()
+    };
     assert!(scope.allows(ScopeCategory::Shape));
     assert!(scope.allows(ScopeCategory::Table));
     assert!(scope.allows(ScopeCategory::Style));
@@ -324,7 +359,10 @@ fn output_scope_all_allows_every_category() {
 fn output_scope_table_only_gates_non_table() {
     use hwp_dvc_core::checker::ScopeCategory;
 
-    let scope = OutputScope { table: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        table: true,
+        ..OutputScope::default()
+    };
     assert!(!scope.allows(ScopeCategory::Shape));
     assert!(scope.allows(ScopeCategory::Table));
     assert!(!scope.allows(ScopeCategory::Style));
@@ -337,7 +375,10 @@ fn output_scope_table_only_gates_non_table() {
 fn output_scope_shape_only_gates_non_shape() {
     use hwp_dvc_core::checker::ScopeCategory;
 
-    let scope = OutputScope { shape: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        shape: true,
+        ..OutputScope::default()
+    };
     assert!(scope.allows(ScopeCategory::Shape));
     assert!(!scope.allows(ScopeCategory::Table));
     assert!(!scope.allows(ScopeCategory::Style));
@@ -349,7 +390,10 @@ fn output_scope_shape_only_gates_non_shape() {
 fn output_scope_tabledetail_enables_table_category() {
     use hwp_dvc_core::checker::ScopeCategory;
 
-    let scope = OutputScope { table_detail: true, ..OutputScope::default() };
+    let scope = OutputScope {
+        table_detail: true,
+        ..OutputScope::default()
+    };
     assert!(!scope.allows(ScopeCategory::Shape));
     assert!(scope.allows(ScopeCategory::Table));
     assert!(!scope.allows(ScopeCategory::Style));

--- a/crates/hwp-dvc-core/tests/xml_output.rs
+++ b/crates/hwp-dvc-core/tests/xml_output.rs
@@ -135,8 +135,14 @@ fn xml_output_pretty_contains_same_elements() {
     let pretty = to_xml(&errors, true).expect("pretty to_xml failed");
 
     // Both must have the same root element.
-    assert!(compact.contains("<dvcErrors>"), "compact must have <dvcErrors>");
-    assert!(pretty.contains("<dvcErrors>"), "pretty must have <dvcErrors>");
+    assert!(
+        compact.contains("<dvcErrors>"),
+        "compact must have <dvcErrors>"
+    );
+    assert!(
+        pretty.contains("<dvcErrors>"),
+        "pretty must have <dvcErrors>"
+    );
 
     // Pretty output must be longer (indentation adds bytes).
     assert!(


### PR DESCRIPTION
## Summary

- Adds all 37 remaining `CHARSHAPE_*` error constants (1001–1039) to `error.rs`, bringing the CharShape category from 4 to 39 registered codes, matching the full `JID_CHAR_SHAPE_*` range in `references/dvc/Source/JsonModel.h`
- Extends `CharShapeSpec` in `spec/mod.rs` with optional fields for every new code group (size, decoration flags, shadow/underline/strikeout/outline detail, misc, border, background)
- Wires validator logic in `checker::char_shape::check` for all fields where `CharShape` carries the needed data; defers sub-detail fields (1019–1028, 1037–1039) with inline TODO comments explaining exactly what extension is needed

## Fields now validated

| Group | Codes | Implementation |
|-------|-------|----------------|
| Size | 1001, 1005, 1006, 1030 | Exact match against `height`, `rel_sz`, `offset`, derived `point` |
| Decoration flags | 1009–1018 | Boolean field equality |
| Misc | 1029, 1031 | `use_font_space`, `use_kerning` field equality |
| Border presence | 1032 | Non-zero `border_fill_id_ref` presence check |

## Deferred fields (constants registered, TODO in code)

- `langset` (1002): requires document-side LangType decoding
- Shadow detail (1019–1022): `CharShape` lacks dedicated sub-fields
- Underline/strikeout/outline detail (1023–1028): header parser does not yet decode sub-element type/shape/color attributes
- Background detail (1037–1039): requires `BorderFill` lookup via `HeaderTables`

## Test plan

- 132 existing unit tests pass unchanged
- 27 new integration tests in `check_char_shape_extended.rs`:
  - Baseline pass fixture (`charshape_pass.hwpx`) produces zero 1000-range errors with all new spec fields `None`
  - Mismatch tests for all newly wired fields
  - JSON round-trip test for all new spec fields
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: all pass

Closes #39. Part of epic #38.