### PR TITLE
refactor: unify Outline/ParaNum level-walker into checker::numbering

### DIFF
--- a/crates/hwp-dvc-core/src/checker/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/mod.rs
@@ -8,6 +8,7 @@ pub mod bullet;
 pub mod char_shape;
 pub mod hyperlink;
 pub mod macro_;
+pub mod numbering;
 pub mod outline_shape;
 pub mod para_num_bullet;
 pub mod para_shape;

--- a/crates/hwp-dvc-core/src/checker/numbering/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/numbering/mod.rs
@@ -1,0 +1,321 @@
+//! Shared level-walker helpers for numbering-based validators.
+//!
+//! Both [`crate::checker::outline_shape`] and
+//! [`crate::checker::para_num_bullet`] traverse `Numbering → ParaHead` level
+//! entries and validate them against a `leveltype` spec array. The structural
+//! traversal logic and the number-shape ordinal mapping are identical in both
+//! checkers; only the error codes differ (3204/3205 for outline-shape vs
+//! 3404/3405 for para-num-bullet).
+//!
+//! This module provides:
+//! - [`num_shape_to_str`] — maps a `NumberShapeType` ordinal to the OWPML
+//!   `numFormat` string. Returns `None` for unknown ordinals.
+//! - [`check_level_sequence`] — validates that a spec's `leveltype` array has
+//!   sequential 1-indexed `level` values and that its length matches the
+//!   document's `Numbering.para_heads` count. Pushes zero, one, or two
+//!   [`DvcErrorInfo`] records using caller-supplied error codes.
+//! - [`make_error`] — constructs a [`DvcErrorInfo`] from a representative
+//!   [`RunTypeInfo`] and an error code, filling all standard metadata fields.
+//!
+//! # Port note
+//!
+//! Extracted from the private helpers in `Checker::CheckOutlineShape` and
+//! `Checker::CheckParaNumBullet` (`references/dvc/Checker.cpp`). Consolidation
+//! is tracked by issue #45 of Epic #38.
+
+use crate::checker::DvcErrorInfo;
+use crate::document::{header::Numbering, RunTypeInfo};
+use crate::error::ErrorContext;
+use crate::spec::LevelType;
+
+// ---------------------------------------------------------------------------
+// Number-shape ordinal mapping
+// ---------------------------------------------------------------------------
+
+/// Map a `NumberShapeType` ordinal (from a DVC spec JSON file) to the
+/// corresponding OWPML `numFormat` attribute string.
+///
+/// The mapping mirrors `NumberShapeType` in
+/// `references/dvc/Source/DVCInterface.h`:
+///
+/// ```text
+/// DIGIT                   = 0
+/// CIRCLED_DIGIT           = 1
+/// ROMAN_CAPITAL           = 2
+/// ROMAN_SMALL             = 3
+/// LATIN_CAPITAL           = 4
+/// LATIN_SMALL             = 5
+/// CIRCLED_LATIN_CAPITAL   = 6
+/// CIRCLED_LATIN_SMALL     = 7
+/// HANGUL_SYLLABLE         = 8
+/// CIRCLED_HANGUL_SYLLABLE = 9
+/// HANGUL_JAMO             = 10
+/// CIRCLED_HANGUL_JAMO     = 11
+/// HANGUL_PHONETIC         = 12
+/// IDEOGRAPH               = 13
+/// CIRCLED_IDEOGRAPH       = 14
+/// DECAGON_CIRCLE          = 15
+/// DECAGON_CIRCLE_HANJA    = 16
+/// ```
+///
+/// Returns `None` for unknown ordinals so callers can skip the comparison
+/// rather than treating every unknown ordinal as a mismatch.
+#[must_use]
+pub fn num_shape_to_str(ordinal: u32) -> Option<&'static str> {
+    match ordinal {
+        0 => Some("DIGIT"),
+        1 => Some("CIRCLED_DIGIT"),
+        2 => Some("ROMAN_CAPITAL"),
+        3 => Some("ROMAN_SMALL"),
+        4 => Some("LATIN_CAPITAL"),
+        5 => Some("LATIN_SMALL"),
+        6 => Some("CIRCLED_LATIN_CAPITAL"),
+        7 => Some("CIRCLED_LATIN_SMALL"),
+        8 => Some("HANGUL_SYLLABLE"),
+        9 => Some("CIRCLED_HANGUL_SYLLABLE"),
+        10 => Some("HANGUL_JAMO"),
+        11 => Some("CIRCLED_HANGUL_JAMO"),
+        12 => Some("HANGUL_PHONETIC"),
+        13 => Some("IDEOGRAPH"),
+        14 => Some("CIRCLED_IDEOGRAPH"),
+        15 => Some("DECAGON_CIRCLE"),
+        16 => Some("DECAGON_CIRCLE_HANJA"),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Level-sequence checker
+// ---------------------------------------------------------------------------
+
+/// Validate the `leveltype` array of a spec against a document [`Numbering`].
+///
+/// Two checks are performed (mirroring `getLevelType` / `CheckOutlineShape` /
+/// `CheckParaNumBullet` in `references/dvc/Checker.cpp`):
+///
+/// 1. **Level-count check** (`leveltype_code`): when `spec_levels` is
+///    non-empty, its length must equal `numbering.para_heads.len()`.
+///    A length mismatch pushes one error with `leveltype_code`.
+///
+/// 2. **Level-index check** (`leveltype_level_code`): each `LevelType` entry
+///    at index `i` must have `level == i + 1` (sequential, 1-indexed).
+///    The first out-of-sequence entry pushes one error with
+///    `leveltype_level_code` and the scan stops.
+///
+/// Both codes are supplied by the caller so the same logic can be used for
+/// `OUTLINESHAPE_LEVELTYPE` (3204) + `OUTLINESHAPE_LEVELTYPE_LEVEL` (3205)
+/// and for `PARANUM_LEVELTYPE` (3404) + `PARANUM_LEVELTYPE_LEVEL` (3405).
+///
+/// Returns the number of errors pushed (0, 1, or 2).
+pub fn check_level_sequence(
+    run: &RunTypeInfo,
+    numbering: &Numbering,
+    spec_levels: &[LevelType],
+    leveltype_code: u32,
+    leveltype_level_code: u32,
+    errors: &mut Vec<DvcErrorInfo>,
+) -> usize {
+    let before = errors.len();
+
+    // --- level-count check ---
+    if !spec_levels.is_empty() && spec_levels.len() != numbering.para_heads.len() {
+        errors.push(make_error(run, leveltype_code));
+    }
+
+    // --- level-index check ---
+    for (idx, lt) in spec_levels.iter().enumerate() {
+        let expected_level = (idx as u32) + 1;
+        if lt.level != expected_level {
+            errors.push(make_error(run, leveltype_level_code));
+            // One error per numbering template is sufficient; stop after the
+            // first out-of-sequence entry to avoid flooding.
+            break;
+        }
+    }
+
+    errors.len() - before
+}
+
+// ---------------------------------------------------------------------------
+// Error construction
+// ---------------------------------------------------------------------------
+
+/// Build a [`DvcErrorInfo`] from a representative run and an error code,
+/// filling every standard metadata field.
+///
+/// This helper is shared between `outline_shape` and `para_num_bullet` so
+/// that both emit identically-shaped [`DvcErrorInfo`] records.
+#[must_use]
+pub fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
+    DvcErrorInfo {
+        para_pr_id_ref: run.para_pr_id_ref,
+        char_pr_id_ref: run.char_pr_id_ref,
+        text: run.text.clone(),
+        page_no: run.page_no,
+        line_no: run.line_no,
+        error_code,
+        table_id: run.table_id,
+        is_in_table: run.is_in_table,
+        is_in_table_in_table: run.is_in_table_in_table,
+        table_row: run.table_row,
+        table_col: run.table_col,
+        is_in_shape: run.is_in_shape,
+        use_hyperlink: run.is_hyperlink,
+        use_style: run.is_style,
+        error_string: crate::error::error_string(error_code, ErrorContext::default()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::header::types::shapes::{Numbering, ParaHead};
+    use crate::document::RunTypeInfo;
+    use crate::spec::LevelType;
+
+    // Sentinel error codes for tests — use values that don't collide with real codes.
+    const CODE_LT: u32 = 9901;
+    const CODE_LL: u32 = 9902;
+
+    fn run() -> RunTypeInfo {
+        RunTypeInfo::default()
+    }
+
+    fn numbering_with_n_levels(n: usize) -> Numbering {
+        Numbering {
+            id: 1,
+            start: 0,
+            para_heads: (1..=(n as u32))
+                .map(|lvl| ParaHead {
+                    level: lvl,
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
+
+    fn levels_sequential(n: u32) -> Vec<LevelType> {
+        (1..=n)
+            .map(|l| LevelType {
+                level: l,
+                numbertype: None,
+                numbershape: 0,
+            })
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // num_shape_to_str
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn num_shape_known_ordinals() {
+        assert_eq!(num_shape_to_str(0), Some("DIGIT"));
+        assert_eq!(num_shape_to_str(8), Some("HANGUL_SYLLABLE"));
+        assert_eq!(num_shape_to_str(16), Some("DECAGON_CIRCLE_HANJA"));
+    }
+
+    #[test]
+    fn num_shape_unknown_ordinal_returns_none() {
+        assert_eq!(num_shape_to_str(17), None);
+        assert_eq!(num_shape_to_str(99), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // check_level_sequence — no errors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_spec_levels_emits_no_errors() {
+        let num = numbering_with_n_levels(3);
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        let pushed = check_level_sequence(&run(), &num, &[], CODE_LT, CODE_LL, &mut errors);
+        assert_eq!(pushed, 0);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn matching_count_and_sequential_levels_emits_no_errors() {
+        let num = numbering_with_n_levels(3);
+        let levels = levels_sequential(3);
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        let pushed = check_level_sequence(&run(), &num, &levels, CODE_LT, CODE_LL, &mut errors);
+        assert_eq!(pushed, 0);
+        assert!(errors.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // check_level_sequence — level-count mismatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn count_mismatch_emits_leveltype_error() {
+        let num = numbering_with_n_levels(1); // doc has 1 level
+        let levels = levels_sequential(2); // spec has 2 levels
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        check_level_sequence(&run(), &num, &levels, CODE_LT, CODE_LL, &mut errors);
+        assert!(
+            errors.iter().any(|e| e.error_code == CODE_LT),
+            "count mismatch must push CODE_LT"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // check_level_sequence — level-index mismatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn non_sequential_level_emits_leveltype_level_error() {
+        let num = numbering_with_n_levels(2);
+        // Spec entry at index 1 has level=3, expected level=2.
+        let levels = vec![
+            LevelType {
+                level: 1,
+                numbertype: None,
+                numbershape: 0,
+            },
+            LevelType {
+                level: 3,
+                numbertype: None,
+                numbershape: 0,
+            },
+        ];
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        check_level_sequence(&run(), &num, &levels, CODE_LT, CODE_LL, &mut errors);
+        assert!(
+            errors.iter().any(|e| e.error_code == CODE_LL),
+            "non-sequential level must push CODE_LL"
+        );
+    }
+
+    #[test]
+    fn only_one_level_level_error_per_numbering() {
+        // Two out-of-sequence entries — but only one error should be emitted.
+        let num = numbering_with_n_levels(3);
+        let levels = vec![
+            LevelType {
+                level: 2,
+                numbertype: None,
+                numbershape: 0,
+            }, // wrong (idx=0 → expected 1)
+            LevelType {
+                level: 3,
+                numbertype: None,
+                numbershape: 0,
+            }, // also wrong
+            LevelType {
+                level: 4,
+                numbertype: None,
+                numbershape: 0,
+            }, // also wrong
+        ];
+        let mut errors: Vec<DvcErrorInfo> = Vec::new();
+        check_level_sequence(&run(), &num, &levels, CODE_LT, CODE_LL, &mut errors);
+        let ll_errors: Vec<_> = errors.iter().filter(|e| e.error_code == CODE_LL).collect();
+        assert_eq!(ll_errors.len(), 1, "at most one CODE_LL error per call");
+    }
+}

--- a/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/outline_shape/mod.rs
@@ -64,16 +64,14 @@
 
 use std::collections::HashSet;
 
+use crate::checker::numbering as num_walker;
 use crate::checker::DvcErrorInfo;
 use crate::document::header::types::enums::HeadingType;
 use crate::document::header::Numbering;
 use crate::document::{Document, RunTypeInfo};
-use crate::error::{
-    outline_shape_codes::{
-        OUTLINESHAPE_LEVELTYPE, OUTLINESHAPE_LEVELTYPE_LEVEL, OUTLINESHAPE_LEVEL_NUMBERSHAPE,
-        OUTLINESHAPE_LEVEL_NUMBERTYPE, OUTLINESHAPE_STARTNUMBER, OUTLINESHAPE_VALUE,
-    },
-    ErrorContext,
+use crate::error::outline_shape_codes::{
+    OUTLINESHAPE_LEVELTYPE, OUTLINESHAPE_LEVELTYPE_LEVEL, OUTLINESHAPE_LEVEL_NUMBERSHAPE,
+    OUTLINESHAPE_LEVEL_NUMBERTYPE, OUTLINESHAPE_STARTNUMBER, OUTLINESHAPE_VALUE,
 };
 use crate::spec::OutlineShapeSpec;
 
@@ -164,7 +162,7 @@ pub fn check(document: &Document, spec: &OutlineShapeSpec) -> Vec<DvcErrorInfo> 
         // Fires OUTLINESHAPE_VALUE (3203).
         if let Some(expected_value) = spec.value {
             if para_head.start != expected_value {
-                errors.push(make_error(run, OUTLINESHAPE_VALUE));
+                errors.push(num_walker::make_error(run, OUTLINESHAPE_VALUE));
             }
         }
 
@@ -172,14 +170,16 @@ pub fn check(document: &Document, spec: &OutlineShapeSpec) -> Vec<DvcErrorInfo> 
         // Only checked when the spec supplies a `numbertype` value.
         if let Some(expected_type) = &spec_entry.numbertype {
             if &para_head.num_format_text != expected_type {
-                errors.push(make_error(run, OUTLINESHAPE_LEVEL_NUMBERTYPE));
+                errors.push(num_walker::make_error(run, OUTLINESHAPE_LEVEL_NUMBERTYPE));
             }
         }
 
         // --- numbershape (enum ordinal → num_format string) ---
-        let expected_shape_str = num_shape_ordinal_to_str(spec_entry.numbershape);
+        // Unknown ordinals return `None` from `num_shape_to_str`; treat as a
+        // definite mismatch (conservative) by mapping `None` to `""`.
+        let expected_shape_str = num_walker::num_shape_to_str(spec_entry.numbershape).unwrap_or("");
         if para_head.num_format != expected_shape_str {
-            errors.push(make_error(run, OUTLINESHAPE_LEVEL_NUMBERSHAPE));
+            errors.push(num_walker::make_error(run, OUTLINESHAPE_LEVEL_NUMBERSHAPE));
         }
     }
 
@@ -194,8 +194,8 @@ pub fn check(document: &Document, spec: &OutlineShapeSpec) -> Vec<DvcErrorInfo> 
 /// per unique numbering template (not per run).
 ///
 /// - `start_number`: `Numbering::start` vs `spec.start_number` → `OUTLINESHAPE_STARTNUMBER` (3202)
-/// - `leveltype` count: `spec.leveltype.len()` vs `numbering.para_heads.len()` → `OUTLINESHAPE_LEVELTYPE` (3204)
-/// - level index: each `spec.leveltype[i].level` vs sequential expected `i+1` → `OUTLINESHAPE_LEVELTYPE_LEVEL` (3205)
+/// - `leveltype` count + level-index: delegated to [`num_walker::check_level_sequence`]
+///   using codes `OUTLINESHAPE_LEVELTYPE` (3204) and `OUTLINESHAPE_LEVELTYPE_LEVEL` (3205).
 fn check_numbering_top_level(
     run: &RunTypeInfo,
     numbering: &Numbering,
@@ -207,111 +207,30 @@ fn check_numbering_top_level(
     // the spec's expected start number.
     if let Some(expected_start) = spec.start_number {
         if numbering.start != expected_start {
-            errors.push(make_error(run, OUTLINESHAPE_STARTNUMBER));
+            errors.push(num_walker::make_error(run, OUTLINESHAPE_STARTNUMBER));
         }
     }
 
-    // --- leveltype wrapper (3204) ---
-    // When the spec defines leveltype entries, the document's numbering
-    // template must declare the same number of levels (para_heads).
-    // A count mismatch means the document is missing required levels or
-    // has surplus levels.
-    if !spec.leveltype.is_empty() && spec.leveltype.len() != numbering.para_heads.len() {
-        errors.push(make_error(run, OUTLINESHAPE_LEVELTYPE));
-    }
-
-    // --- leveltype level index (3205) ---
-    // Each spec `leveltype` entry carries a `level` field that must be a
-    // 1-indexed sequential integer matching its position in the array.
-    // Spec entry at index 0 → expected level 1, index 1 → level 2, etc.
-    // A mismatch means the spec (or the document it encodes) has a
-    // non-sequential level declaration.
-    for (idx, lt) in spec.leveltype.iter().enumerate() {
-        let expected_level = (idx as u32) + 1;
-        if lt.level != expected_level {
-            errors.push(make_error(run, OUTLINESHAPE_LEVELTYPE_LEVEL));
-            // One error per numbering template is sufficient; break after
-            // the first out-of-sequence entry to avoid flooding.
-            break;
-        }
-    }
+    // --- leveltype count (3204) + level-index (3205) ---
+    // Delegated to the shared level-sequence walker. Both the count check and
+    // the index-sequential check are structurally identical to the para-num
+    // variant; only the error codes differ.
+    num_walker::check_level_sequence(
+        run,
+        numbering,
+        &spec.leveltype,
+        OUTLINESHAPE_LEVELTYPE,
+        OUTLINESHAPE_LEVELTYPE_LEVEL,
+        errors,
+    );
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Map a `numbershape` ordinal (from the DVC JSON spec) to the OWPML
-/// `numFormat` string stored in [`ParaHead::num_format`].
-///
-/// The ordinal enumeration mirrors the C++ `NumShapeType` enum:
-///
-/// ```text
-/// 0  = DIGIT
-/// 1  = CIRCLED_DIGIT
-/// 2  = ROMAN_CAPITAL
-/// 3  = ROMAN_SMALL
-/// 4  = LATIN_CAPITAL
-/// 5  = LATIN_SMALL
-/// 6  = CIRCLED_LATIN_CAPITAL
-/// 7  = CIRCLED_LATIN_SMALL
-/// 8  = HANGUL_SYLLABLE
-/// 9  = CIRCLED_HANGUL_SYLLABLE
-/// 10 = HANGUL_JAMO
-/// 11 = CIRCLED_HANGUL_JAMO
-/// 12 = HANGUL_PHONETIC
-/// 13 = IDEOGRAPH
-/// 14 = CIRCLED_IDEOGRAPH
-/// 15 = DECAGON_CIRCLE
-/// 16 = DECAGON_CIRCLE_HANJA
-/// ```
-///
-/// Unknown ordinals map to `""` so the `!=` comparison that follows will
-/// always fire — treating an unknown spec value as a definite mismatch is
-/// the safe / conservative choice.
-fn num_shape_ordinal_to_str(ordinal: u32) -> &'static str {
-    match ordinal {
-        0 => "DIGIT",
-        1 => "CIRCLED_DIGIT",
-        2 => "ROMAN_CAPITAL",
-        3 => "ROMAN_SMALL",
-        4 => "LATIN_CAPITAL",
-        5 => "LATIN_SMALL",
-        6 => "CIRCLED_LATIN_CAPITAL",
-        7 => "CIRCLED_LATIN_SMALL",
-        8 => "HANGUL_SYLLABLE",
-        9 => "CIRCLED_HANGUL_SYLLABLE",
-        10 => "HANGUL_JAMO",
-        11 => "CIRCLED_HANGUL_JAMO",
-        12 => "HANGUL_PHONETIC",
-        13 => "IDEOGRAPH",
-        14 => "CIRCLED_IDEOGRAPH",
-        15 => "DECAGON_CIRCLE",
-        16 => "DECAGON_CIRCLE_HANJA",
-        _ => "",
-    }
-}
-
-/// Build a [`DvcErrorInfo`] from a representative run and an error code.
-fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
-    DvcErrorInfo {
-        para_pr_id_ref: run.para_pr_id_ref,
-        char_pr_id_ref: run.char_pr_id_ref,
-        text: run.text.clone(),
-        page_no: run.page_no,
-        line_no: run.line_no,
-        error_code,
-        table_id: run.table_id,
-        is_in_table: run.is_in_table,
-        is_in_table_in_table: run.is_in_table_in_table,
-        table_row: run.table_row,
-        table_col: run.table_col,
-        is_in_shape: run.is_in_shape,
-        use_hyperlink: run.is_hyperlink,
-        use_style: run.is_style,
-        error_string: crate::error::error_string(error_code, ErrorContext::default()),
-    }
-}
+// All shared helpers (num_shape_to_str, make_error, check_level_sequence)
+// live in `crate::checker::numbering`. This module has no private helpers
+// of its own beyond those delegations above.
 
 // ---------------------------------------------------------------------------
 // Unit tests
@@ -783,17 +702,18 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // num_shape_ordinal_to_str
+    // num_shape_to_str (via shared numbering helper)
     // -----------------------------------------------------------------------
 
     #[test]
     fn ordinal_mapping_spot_checks() {
-        assert_eq!(num_shape_ordinal_to_str(0), "DIGIT");
-        assert_eq!(num_shape_ordinal_to_str(1), "CIRCLED_DIGIT");
-        assert_eq!(num_shape_ordinal_to_str(8), "HANGUL_SYLLABLE");
-        assert_eq!(num_shape_ordinal_to_str(9), "CIRCLED_HANGUL_SYLLABLE");
-        assert_eq!(num_shape_ordinal_to_str(10), "HANGUL_JAMO");
-        assert_eq!(num_shape_ordinal_to_str(16), "DECAGON_CIRCLE_HANJA");
-        assert_eq!(num_shape_ordinal_to_str(99), ""); // unknown → empty
+        use crate::checker::numbering::num_shape_to_str;
+        assert_eq!(num_shape_to_str(0), Some("DIGIT"));
+        assert_eq!(num_shape_to_str(1), Some("CIRCLED_DIGIT"));
+        assert_eq!(num_shape_to_str(8), Some("HANGUL_SYLLABLE"));
+        assert_eq!(num_shape_to_str(9), Some("CIRCLED_HANGUL_SYLLABLE"));
+        assert_eq!(num_shape_to_str(10), Some("HANGUL_JAMO"));
+        assert_eq!(num_shape_to_str(16), Some("DECAGON_CIRCLE_HANJA"));
+        assert_eq!(num_shape_to_str(99), None); // unknown → None
     }
 }

--- a/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
+++ b/crates/hwp-dvc-core/src/checker/para_num_bullet/mod.rs
@@ -22,10 +22,9 @@
 //!
 //! # Level walking
 //!
-//! TODO: Issue #45 will unify the level-walker logic between this module and
-//! `checker::outline_shape` into a shared `checker::level_walk` helper to
-//! avoid duplication. For now the two modules keep their own copies. See the
-//! Epic #38 technical notes for context.
+//! The level-walker logic (number-shape ordinal mapping, level-count and
+//! level-index validation) is shared with `checker::outline_shape` via the
+//! [`crate::checker::numbering`] helper module introduced by issue #45.
 //!
 //! # Covered error codes
 //!
@@ -45,15 +44,13 @@
 
 use std::collections::HashSet;
 
+use crate::checker::numbering as num_walker;
 use crate::checker::DvcErrorInfo;
 use crate::document::header::{HeadingType, Numbering, ParaHead};
 use crate::document::{Document, RunTypeInfo};
-use crate::error::{
-    para_num_bullet_codes::{
-        PARANUM_LEVELTYPE, PARANUM_LEVELTYPE_LEVEL, PARANUM_LEVEL_NUMBERSHAPE,
-        PARANUM_LEVEL_NUMBERTYPE, PARANUM_STARTNUMBER, PARANUM_VALUE,
-    },
-    ErrorContext,
+use crate::error::para_num_bullet_codes::{
+    PARANUM_LEVELTYPE, PARANUM_LEVELTYPE_LEVEL, PARANUM_LEVEL_NUMBERSHAPE,
+    PARANUM_LEVEL_NUMBERTYPE, PARANUM_STARTNUMBER, PARANUM_VALUE,
 };
 use crate::spec::ParaNumBulletSpec;
 
@@ -122,7 +119,7 @@ pub fn check(document: &Document, spec: &ParaNumBulletSpec) -> Vec<DvcErrorInfo>
         if let Some(expected_restart) = spec.start_number {
             let doc_restarts = numbering.start != 0;
             if doc_restarts != expected_restart {
-                errors.push(make_error(run, PARANUM_STARTNUMBER));
+                errors.push(num_walker::make_error(run, PARANUM_STARTNUMBER));
             }
         }
 
@@ -133,7 +130,7 @@ pub fn check(document: &Document, spec: &ParaNumBulletSpec) -> Vec<DvcErrorInfo>
         if let Some(expected_value) = spec.value {
             let first_head_start = numbering.para_heads.first().map(|ph| ph.start).unwrap_or(0);
             if first_head_start != expected_value {
-                errors.push(make_error(run, PARANUM_VALUE));
+                errors.push(num_walker::make_error(run, PARANUM_VALUE));
             }
         }
 
@@ -146,7 +143,7 @@ pub fn check(document: &Document, spec: &ParaNumBulletSpec) -> Vec<DvcErrorInfo>
             None => {
                 // No paraHead found for this heading level even though the spec
                 // declares leveltype constraints — emit the wrapper error (3404).
-                errors.push(make_error(run, PARANUM_LEVELTYPE));
+                errors.push(num_walker::make_error(run, PARANUM_LEVELTYPE));
                 continue;
             }
         };
@@ -196,7 +193,7 @@ fn check_para_head(
     // reached, but we emit the error defensively so that callers driving the
     // check with a pre-resolved spec entry do not silently skip it.
     if spec_level.level != para_head.level {
-        errors.push(make_error(run, PARANUM_LEVELTYPE_LEVEL));
+        errors.push(num_walker::make_error(run, PARANUM_LEVELTYPE_LEVEL));
     }
 
     // --- numbertype check (3406) ---
@@ -205,7 +202,7 @@ fn check_para_head(
     // holds the OWPML `numFormat` attribute value.
     if let Some(ref expected_nt) = spec_level.numbertype {
         if *expected_nt != para_head.num_format {
-            errors.push(make_error(run, PARANUM_LEVEL_NUMBERTYPE));
+            errors.push(num_walker::make_error(run, PARANUM_LEVEL_NUMBERTYPE));
         }
     }
 
@@ -213,84 +210,20 @@ fn check_para_head(
     // The spec's `numbershape` field is a u32 ordinal that maps to the
     // `NumberShapeType` enum in the reference C++. We convert it to the
     // corresponding OWPML `numFormat` attribute string and compare.
-    let expected_shape_str = number_shape_to_format_str(spec_level.numbershape);
-    if let Some(expected_str) = expected_shape_str {
+    // Unknown ordinals return `None` and skip the comparison (future-proofing).
+    if let Some(expected_str) = num_walker::num_shape_to_str(spec_level.numbershape) {
         if expected_str != para_head.num_format {
-            errors.push(make_error(run, PARANUM_LEVEL_NUMBERSHAPE));
+            errors.push(num_walker::make_error(run, PARANUM_LEVEL_NUMBERSHAPE));
         }
     }
 }
 
-/// Map a `NumberShapeType` ordinal (from the DVC spec JSON) to the
-/// corresponding OWPML `numFormat` attribute string.
-///
-/// The mapping mirrors the `NumberShapeType` enum in
-/// `references/dvc/Source/DVCInterface.h`:
-///
-/// ```text
-/// DIGIT                  = 0
-/// CIRCLED_DIGIT          = 1
-/// ROMAN_CAPITAL          = 2
-/// ROMAN_SMALL            = 3
-/// LATIN_CAPITAL          = 4
-/// LATIN_SMALL            = 5
-/// CIRCLED_LATIN_CAPITAL  = 6
-/// CIRCLED_LATIN_SMALL    = 7
-/// HANGUL_SYLLABLE        = 8
-/// CIRCLED_HANGUL_SYLLABLE= 9
-/// HANGUL_JAMO            = 10
-/// CIRCLED_HANGUL_JAMO    = 11
-/// HANGUL_PHONETIC        = 12
-/// IDEOGRAPH              = 13
-/// CIRCLED_IDEOGRAPH      = 14
-/// DECAGON_CIRCLE         = 15
-/// DECAGON_CIRCLE_HANJA   = 16
-/// ```
-///
-/// Returns `None` for unknown ordinals (future-proofing).
-fn number_shape_to_format_str(ordinal: u32) -> Option<&'static str> {
-    match ordinal {
-        0 => Some("DIGIT"),
-        1 => Some("CIRCLED_DIGIT"),
-        2 => Some("ROMAN_CAPITAL"),
-        3 => Some("ROMAN_SMALL"),
-        4 => Some("LATIN_CAPITAL"),
-        5 => Some("LATIN_SMALL"),
-        6 => Some("CIRCLED_LATIN_CAPITAL"),
-        7 => Some("CIRCLED_LATIN_SMALL"),
-        8 => Some("HANGUL_SYLLABLE"),
-        9 => Some("CIRCLED_HANGUL_SYLLABLE"),
-        10 => Some("HANGUL_JAMO"),
-        11 => Some("CIRCLED_HANGUL_JAMO"),
-        12 => Some("HANGUL_PHONETIC"),
-        13 => Some("IDEOGRAPH"),
-        14 => Some("CIRCLED_IDEOGRAPH"),
-        15 => Some("DECAGON_CIRCLE"),
-        16 => Some("DECAGON_CIRCLE_HANJA"),
-        _ => None,
-    }
-}
-
-/// Build a [`DvcErrorInfo`] from a representative run and an error code.
-fn make_error(run: &RunTypeInfo, error_code: u32) -> DvcErrorInfo {
-    DvcErrorInfo {
-        para_pr_id_ref: run.para_pr_id_ref,
-        char_pr_id_ref: run.char_pr_id_ref,
-        text: run.text.clone(),
-        page_no: run.page_no,
-        line_no: run.line_no,
-        error_code,
-        table_id: run.table_id,
-        is_in_table: run.is_in_table,
-        is_in_table_in_table: run.is_in_table_in_table,
-        table_row: run.table_row,
-        table_col: run.table_col,
-        is_in_shape: run.is_in_shape,
-        use_hyperlink: run.is_hyperlink,
-        use_style: run.is_style,
-        error_string: crate::error::error_string(error_code, ErrorContext::default()),
-    }
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+// All shared helpers (num_shape_to_str via num_walker::num_shape_to_str,
+// make_error via num_walker::make_error) now live in
+// `crate::checker::numbering`. This module has no private helpers of its own.
 
 // ---------------------------------------------------------------------------
 // Unit tests
@@ -808,11 +741,12 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // number_shape_to_format_str mapping
+    // num_shape_to_str mapping (via shared numbering helper)
     // -------------------------------------------------------------------------
 
     #[test]
     fn number_shape_mapping_covers_all_known_ordinals() {
+        use crate::checker::numbering::num_shape_to_str;
         let known = [
             (0u32, "DIGIT"),
             (1, "CIRCLED_DIGIT"),
@@ -834,13 +768,13 @@ mod tests {
         ];
         for (ordinal, expected) in known {
             assert_eq!(
-                number_shape_to_format_str(ordinal),
+                num_shape_to_str(ordinal),
                 Some(expected),
                 "ordinal {ordinal} must map to {expected}"
             );
         }
         assert_eq!(
-            number_shape_to_format_str(17),
+            num_shape_to_str(17),
             None,
             "unknown ordinal must return None"
         );


### PR DESCRIPTION
## Summary

- Extracts shared level-walker logic from `checker::outline_shape` and `checker::para_num_bullet` into a new `checker::numbering` module
- The new module exposes `num_shape_to_str`, `check_level_sequence`, and `make_error` — called by both validators with their respective error codes
- Removes the TODO comment in `para_num_bullet/mod.rs` pointing to this issue
- No behavior changes: error codes, error counts, and output are identical pre- and post-refactor

## Changes

- New: `crates/hwp-dvc-core/src/checker/numbering/mod.rs` — shared helpers with unit tests
- Modified: `checker/mod.rs` — adds `pub mod numbering`
- Modified: `checker/outline_shape/mod.rs` — delegates to `num_walker::*`, removes duplicate private helpers (-154 lines on the walker portion)
- Modified: `checker/para_num_bullet/mod.rs` — delegates to `num_walker::*`, removes duplicate private helpers (-116 lines on the walker portion)

## Test plan

- [x] `cargo test --workspace` — all 215 unit + integration tests pass
- [x] `cargo test --workspace --features xml` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — applied, no diffs remaining

Closes #45
Part of #38